### PR TITLE
Add bottom margin to .site-title

### DIFF
--- a/.dev/sass/layouts/_header.scss
+++ b/.dev/sass/layouts/_header.scss
@@ -77,6 +77,7 @@ body.no-max-width .hero-inner {
 	font-weight: 400;
 	font-size: 3.25rem;
 	line-height: 1;
+	margin-bottom: 10px;
 
 	a {
 		color: $color__site-title-text;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1630,7 +1630,8 @@ body.no-max-width .hero-inner {
   margin-bottom: 0;
   font-weight: 400;
   font-size: 3.25rem;
-  line-height: 1; }
+  line-height: 1;
+  margin-bottom: 10px; }
   .site-title a {
     color: #fca903; }
     .site-title a:hover, .site-title a:visited:hover {

--- a/style.css
+++ b/style.css
@@ -1630,7 +1630,8 @@ body.no-max-width .hero-inner {
   margin-bottom: 0;
   font-weight: 400;
   font-size: 3.25rem;
-  line-height: 1; }
+  line-height: 1;
+  margin-bottom: 10px; }
   .site-title a {
     color: #fca903; }
     .site-title a:hover, .site-title a:visited:hover {


### PR DESCRIPTION
Adding a small bottom-margin to the `.site-title` element. 

Since we had no spacing between the title and description, if the title contained a low hanging character such as g or y the letter overlapped with the description characters.
