### PR TITLE
WooCommerce updates

### DIFF
--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -120,6 +120,16 @@
 				&:hover {
 					opacity: .85;
 				}
+
+				.variation {
+					.variation-color {
+						margin: 0;
+
+						p {
+							margin: 0 0 0 5px;
+						}
+					}
+				}
 			}
 		}
 	}

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -156,7 +156,7 @@
 	}
 
 	.primer-woocommerce .cart .qty {
-		padding: 0.2em;
+		padding: 0.19em;
 	}
 
 	#reviews #comments ol.commentlist li {
@@ -178,6 +178,10 @@
 			margin-right: 0;
 		}
 
+	}
+
+	table.variations tr:hover td {
+		background-color: transparent;
 	}
 
 	table.cart {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -159,6 +159,16 @@
 		padding: 0.19em;
 	}
 
+	span.onsale,
+	ul.products li.product .onsale {
+		padding: 2px 8px;
+		border-radius: 0;
+		margin: 0;
+		min-height: auto;
+		min-width: auto;
+		line-height: inherit;
+	}
+
 	#reviews #comments ol.commentlist li {
 
 		img.avatar {
@@ -196,19 +206,6 @@
 		}
 	}
 
-}
-
-body.woocommerce,
-body.single-product {
-	span.onsale,
-	ul.products li.product .onsale {
-		padding: 2px 8px;
-		border-radius: 0;
-		margin: 0;
-		min-height: auto;
-		min-width: auto;
-		line-height: inherit;
-	}
 }
 
 body.single-product {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -129,9 +129,73 @@
 	}
 }
 
-body.post-type-archive,
+.woocommerce-page {
+
+	div.product {
+
+		.woocommerce-product-gallery {
+
+			figure.woocommerce-product-gallery__wrapper {
+				margin: 0;
+			}
+
+		}
+
+		.summary {
+			margin-top: 0;
+		}
+
+		.commentlist {
+			padding-left: 0;
+		}
+
+	}
+
+	ul.products li.product.primer-2-column-product {
+		width: 48.05%;
+	}
+
+	.primer-woocommerce .cart .qty {
+		padding: 0.2em;
+	}
+
+	#reviews #comments ol.commentlist li {
+
+		img.avatar {
+			width: 60px;
+		}
+
+		.comment-text {
+			margin: 0 0 0 80px;
+		}
+
+	}
+
+	form.woocommerce-cart-form {
+
+		table.cart td.actions #coupon_code {
+			width: 55%;
+			margin-right: 0;
+		}
+
+	}
+
+	table.cart {
+		img {
+			width: 100%;
+			max-width: 100px;
+			margin-bottom: 0;
+		}
+
+		td.actions .input-text {
+			padding: 10px !important;
+		}
+	}
+
+}
+
+body.woocommerce,
 body.single-product {
-	/* On Sale Badge */
 	span.onsale,
 	ul.products li.product .onsale {
 		padding: 2px 8px;
@@ -155,16 +219,6 @@ body.woocommerce-cart {
 	.primer-wc-cart-sub-menu {
 		display: none;
 	}
-}
-
-.woocommerce #content table.cart img,
-.woocommerce table.cart img,
-.woocommerce-page #content table.cart img,
-.woocommerce-page table.cart img {
-	width: 100%;
-	max-width: 90px;
-	display: block;
-	margin: 0 auto;
 }
 
 .woocommerce #content table.cart td.actions .input-text,

--- a/functions.php
+++ b/functions.php
@@ -306,7 +306,8 @@ function scribbles_colors( $colors ) {
 		'button_color' => array(
 			'default'  => '#b5345f',
 			'css'     => array(
-				'.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a' => array(
+				'.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a,
+				.woocommerce button.button.alt.disabled, .woocommerce button.button.alt.disabled:hover' => array(
 					'background-color' => '%1$s',
 				),
 			),
@@ -320,7 +321,8 @@ function scribbles_colors( $colors ) {
 		'background_color' => array(
 			'default' => '#ffffff',
 			'css'     => array(
-				'.woocommerce-cart-menu-item .sub-menu, .woocommerce-cart-menu-item ul.sub-menu' => array(
+				'.woocommerce-cart-menu-item .sub-menu, .woocommerce-cart-menu-item ul.sub-menu,
+				table.variations tr:hover td' => array(
 					'background-color' => '%1$s',
 				),
 			),

--- a/functions.php
+++ b/functions.php
@@ -305,12 +305,6 @@ function scribbles_colors( $colors ) {
 		),
 		'button_color' => array(
 			'default'  => '#b5345f',
-			'css'     => array(
-				'.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a,
-				.woocommerce button.button.alt.disabled, .woocommerce button.button.alt.disabled:hover' => array(
-					'background-color' => '%1$s',
-				),
-			),
 		),
 		'button_text_color' => array(
 			'default'  => '#ffffff',
@@ -320,12 +314,6 @@ function scribbles_colors( $colors ) {
 		 */
 		'background_color' => array(
 			'default' => '#ffffff',
-			'css'     => array(
-				'.woocommerce-cart-menu-item .sub-menu, .woocommerce-cart-menu-item ul.sub-menu,
-				table.variations tr:hover td' => array(
-					'background-color' => '%1$s',
-				),
-			),
 		),
 		'hero_background_color' => array(
 			'default' => '#686868',

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2324,7 +2324,7 @@ body.no-max-width .site-info-wrapper .site-info {
   width: 48.05%; }
 
 .woocommerce-page .primer-woocommerce .cart .qty {
-  padding: 0.2em; }
+  padding: 0.19em; }
 
 .woocommerce-page #reviews #comments ol.commentlist li img.avatar {
   width: 60px; }
@@ -2335,6 +2335,9 @@ body.no-max-width .site-info-wrapper .site-info {
 .woocommerce-page form.woocommerce-cart-form table.cart td.actions #coupon_code {
   width: 55%;
   margin-left: 0; }
+
+.woocommerce-page table.variations tr:hover td {
+  background-color: transparent; }
 
 .woocommerce-page table.cart img {
   width: 100%;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1684,7 +1684,7 @@ body.no-max-width .hero-inner {
   font-size: 3em; }
 
 body.custom-header-image .hero {
-  text-shadow: -1px -1px 30px rgba(0, 0, 0, 0.5); }
+  text-shadow: -1px 1px 30px rgba(0, 0, 0, 0.5); }
 
 .header-image img {
   display: block; }
@@ -2311,20 +2311,50 @@ body.no-max-width .site-info-wrapper .site-info {
   .primer-wc-cart-menu .cart-preview-count {
     margin-right: 8px; }
 
-body.post-type-archive,
-body.single-product {
-  /* On Sale Badge */ }
-  body.post-type-archive span.onsale,
-  body.post-type-archive ul.products li.product .onsale,
-  body.single-product span.onsale,
-  body.single-product ul.products li.product .onsale {
-    padding: 2px 8px;
-    -webkit-border-radius: 0;
-    border-radius: 0;
-    margin: 0;
-    min-height: auto;
-    min-width: auto;
-    line-height: inherit; }
+.woocommerce-page div.product .woocommerce-product-gallery figure.woocommerce-product-gallery__wrapper {
+  margin: 0; }
+
+.woocommerce-page div.product .summary {
+  margin-top: 0; }
+
+.woocommerce-page div.product .commentlist {
+  padding-right: 0; }
+
+.woocommerce-page ul.products li.product.primer-2-column-product {
+  width: 48.05%; }
+
+.woocommerce-page .primer-woocommerce .cart .qty {
+  padding: 0.2em; }
+
+.woocommerce-page #reviews #comments ol.commentlist li img.avatar {
+  width: 60px; }
+
+.woocommerce-page #reviews #comments ol.commentlist li .comment-text {
+  margin: 0 80px 0 0; }
+
+.woocommerce-page form.woocommerce-cart-form table.cart td.actions #coupon_code {
+  width: 55%;
+  margin-left: 0; }
+
+.woocommerce-page table.cart img {
+  width: 100%;
+  max-width: 100px;
+  margin-bottom: 0; }
+
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 10px !important; }
+
+body.woocommerce span.onsale,
+body.woocommerce ul.products li.product .onsale,
+body.single-product span.onsale,
+body.single-product ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;
@@ -2333,15 +2363,6 @@ body.single-product span.onsale {
 
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
-
-.woocommerce #content table.cart img,
-.woocommerce table.cart img,
-.woocommerce-page #content table.cart img,
-.woocommerce-page table.cart img {
-  width: 100%;
-  max-width: 90px;
-  display: block;
-  margin: 0 auto; }
 
 .woocommerce #content table.cart td.actions .input-text,
 .woocommerce table.cart td.actions .input-text,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2341,6 +2341,10 @@ body.no-max-width .site-info-wrapper .site-info {
           text-indent: 1.75rem; }
         .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item:hover {
           opacity: .85; }
+        .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item .variation .variation-color {
+          margin: 0; }
+          .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item .variation .variation-color p {
+            margin: 0 5px 0 0; }
   .primer-wc-cart-menu .cart-preview-count {
     margin-right: 8px; }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2326,6 +2326,16 @@ body.no-max-width .site-info-wrapper .site-info {
 .woocommerce-page .primer-woocommerce .cart .qty {
   padding: 0.19em; }
 
+.woocommerce-page span.onsale,
+.woocommerce-page ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
+
 .woocommerce-page #reviews #comments ol.commentlist li img.avatar {
   width: 60px; }
 
@@ -2346,18 +2356,6 @@ body.no-max-width .site-info-wrapper .site-info {
 
 .woocommerce-page table.cart td.actions .input-text {
   padding: 10px !important; }
-
-body.woocommerce span.onsale,
-body.woocommerce ul.products li.product .onsale,
-body.single-product span.onsale,
-body.single-product ul.products li.product .onsale {
-  padding: 2px 8px;
-  -webkit-border-radius: 0;
-  border-radius: 0;
-  margin: 0;
-  min-height: auto;
-  min-width: auto;
-  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style.css
+++ b/style.css
@@ -2311,20 +2311,50 @@ body.no-max-width .site-info-wrapper .site-info {
   .primer-wc-cart-menu .cart-preview-count {
     margin-left: 8px; }
 
-body.post-type-archive,
-body.single-product {
-  /* On Sale Badge */ }
-  body.post-type-archive span.onsale,
-  body.post-type-archive ul.products li.product .onsale,
-  body.single-product span.onsale,
-  body.single-product ul.products li.product .onsale {
-    padding: 2px 8px;
-    -webkit-border-radius: 0;
-    border-radius: 0;
-    margin: 0;
-    min-height: auto;
-    min-width: auto;
-    line-height: inherit; }
+.woocommerce-page div.product .woocommerce-product-gallery figure.woocommerce-product-gallery__wrapper {
+  margin: 0; }
+
+.woocommerce-page div.product .summary {
+  margin-top: 0; }
+
+.woocommerce-page div.product .commentlist {
+  padding-left: 0; }
+
+.woocommerce-page ul.products li.product.primer-2-column-product {
+  width: 48.05%; }
+
+.woocommerce-page .primer-woocommerce .cart .qty {
+  padding: 0.2em; }
+
+.woocommerce-page #reviews #comments ol.commentlist li img.avatar {
+  width: 60px; }
+
+.woocommerce-page #reviews #comments ol.commentlist li .comment-text {
+  margin: 0 0 0 80px; }
+
+.woocommerce-page form.woocommerce-cart-form table.cart td.actions #coupon_code {
+  width: 55%;
+  margin-right: 0; }
+
+.woocommerce-page table.cart img {
+  width: 100%;
+  max-width: 100px;
+  margin-bottom: 0; }
+
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 10px !important; }
+
+body.woocommerce span.onsale,
+body.woocommerce ul.products li.product .onsale,
+body.single-product span.onsale,
+body.single-product ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;
@@ -2333,15 +2363,6 @@ body.single-product span.onsale {
 
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
-
-.woocommerce #content table.cart img,
-.woocommerce table.cart img,
-.woocommerce-page #content table.cart img,
-.woocommerce-page table.cart img {
-  width: 100%;
-  max-width: 90px;
-  display: block;
-  margin: 0 auto; }
 
 .woocommerce #content table.cart td.actions .input-text,
 .woocommerce table.cart td.actions .input-text,

--- a/style.css
+++ b/style.css
@@ -2341,6 +2341,10 @@ body.no-max-width .site-info-wrapper .site-info {
           text-indent: 1.75rem; }
         .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item:hover {
           opacity: .85; }
+        .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item .variation .variation-color {
+          margin: 0; }
+          .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item .variation .variation-color p {
+            margin: 0 0 0 5px; }
   .primer-wc-cart-menu .cart-preview-count {
     margin-left: 8px; }
 

--- a/style.css
+++ b/style.css
@@ -2326,6 +2326,16 @@ body.no-max-width .site-info-wrapper .site-info {
 .woocommerce-page .primer-woocommerce .cart .qty {
   padding: 0.19em; }
 
+.woocommerce-page span.onsale,
+.woocommerce-page ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
+
 .woocommerce-page #reviews #comments ol.commentlist li img.avatar {
   width: 60px; }
 
@@ -2346,18 +2356,6 @@ body.no-max-width .site-info-wrapper .site-info {
 
 .woocommerce-page table.cart td.actions .input-text {
   padding: 10px !important; }
-
-body.woocommerce span.onsale,
-body.woocommerce ul.products li.product .onsale,
-body.single-product span.onsale,
-body.single-product ul.products li.product .onsale {
-  padding: 2px 8px;
-  -webkit-border-radius: 0;
-  border-radius: 0;
-  margin: 0;
-  min-height: auto;
-  min-width: auto;
-  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style.css
+++ b/style.css
@@ -2324,7 +2324,7 @@ body.no-max-width .site-info-wrapper .site-info {
   width: 48.05%; }
 
 .woocommerce-page .primer-woocommerce .cart .qty {
-  padding: 0.2em; }
+  padding: 0.19em; }
 
 .woocommerce-page #reviews #comments ol.commentlist li img.avatar {
   width: 60px; }
@@ -2335,6 +2335,9 @@ body.no-max-width .site-info-wrapper .site-info {
 .woocommerce-page form.woocommerce-cart-form table.cart td.actions #coupon_code {
   width: 55%;
   margin-right: 0; }
+
+.woocommerce-page table.variations tr:hover td {
+  background-color: transparent; }
 
 .woocommerce-page table.cart img {
   width: 100%;


### PR DESCRIPTION
Update WooCommerce compatibility styles.

For a full list of tweaks see https://github.com/godaddy/wp-primer-theme/pull/182

Additional tweaks here include:

1) Disabled WooCommerce buttons Inheriting the button color from the customizer/color scheme
2) On the shop page, the `sale` badge was still displayed as a circle.