### PR TITLE
Introduce video header support

### DIFF
--- a/.dev/sass/layouts/_header.scss
+++ b/.dev/sass/layouts/_header.scss
@@ -1,5 +1,48 @@
 .site-header {
 	position: relative;
+
+	&.video-header {
+
+		+.main-navigation-container +.hero {
+			background-color: #000;
+			color: #000;
+			display: flex;
+			align-items: center;
+			flex-direction: row-reverse;
+			position: relative;
+
+			aside {
+				position: relative;
+			}
+
+			.hero-inner {
+				z-index: 1;
+			}
+
+			#wp-custom-header {
+				position: absolute;
+				height: 100%;
+				top: 0;
+				left: 0;
+
+				img {
+					display: none;
+				}
+			}
+
+			#wp-custom-header-video-button {
+				position: absolute;
+				bottom: 0.5em;
+				right: 1em;
+				opacity: 0.5;
+				z-index: 11;
+			}
+
+			iframe#wp-custom-header-video {
+				height: 100%;
+			}
+		}
+	}
 }
 
 .hero {

--- a/.dev/sass/layouts/_header.scss
+++ b/.dev/sass/layouts/_header.scss
@@ -10,6 +10,10 @@
 	background-repeat: no-repeat;
 	z-index: 0;
 
+	#wp-custom-header img {
+		display: none;
+	}
+
 	.hero-inner {
 		@include container($container-size);
 

--- a/.dev/sass/layouts/_header.scss
+++ b/.dev/sass/layouts/_header.scss
@@ -1,48 +1,7 @@
+@import "video-header";
+
 .site-header {
 	position: relative;
-
-	&.video-header {
-
-		+.main-navigation-container +.hero {
-			background-color: #000;
-			color: #000;
-			display: flex;
-			align-items: center;
-			flex-direction: row-reverse;
-			position: relative;
-
-			aside {
-				position: relative;
-			}
-
-			.hero-inner {
-				z-index: 1;
-			}
-
-			#wp-custom-header {
-				position: absolute;
-				height: 100%;
-				top: 0;
-				left: 0;
-
-				img {
-					display: none;
-				}
-			}
-
-			#wp-custom-header-video-button {
-				position: absolute;
-				bottom: 0.5em;
-				right: 1em;
-				opacity: 0.5;
-				z-index: 11;
-			}
-
-			iframe#wp-custom-header-video {
-				height: 100%;
-			}
-		}
-	}
 }
 
 .hero {

--- a/.dev/sass/layouts/_video-header.scss
+++ b/.dev/sass/layouts/_video-header.scss
@@ -1,0 +1,39 @@
+.site-header.video-header {
+
+	+.main-navigation-container +.hero {
+		background-color: #000;
+		color: #000;
+		position: relative;
+
+		aside {
+			position: relative;
+		}
+
+		.hero-inner {
+			z-index: 1;
+		}
+
+		#wp-custom-header {
+			position: absolute;
+			height: 100%;
+			top: 0;
+			left: 0;
+
+			img {
+				display: none;
+			}
+		}
+
+		#wp-custom-header-video-button {
+			position: absolute;
+			bottom: 0.5em;
+			right: 1em;
+			opacity: 0.5;
+			z-index: 11;
+		}
+
+		iframe#wp-custom-header-video {
+			height: 100%;
+		}
+	}
+}

--- a/.dev/sass/layouts/_video-header.scss
+++ b/.dev/sass/layouts/_video-header.scss
@@ -18,21 +18,15 @@
 			right: 0;
 			bottom: 0;
 			margin: auto;
-
-			img {
-				display: none;
-			}
 		}
 
 		#wp-custom-header-video-button {
 			position: absolute;
-			top: 72vh;
+			bottom: 20vh;
 			right: 1em;
 			opacity: 0.5;
-
-			@media #{$medium-only} {
-				top: 68vh;
-			}
+			font-size: 1rem;
+			padding: 0.65em .85em;
 		}
 
 		iframe#wp-custom-header-video {

--- a/.dev/sass/layouts/_video-header.scss
+++ b/.dev/sass/layouts/_video-header.scss
@@ -9,10 +9,6 @@
 			position: relative;
 		}
 
-		.hero-inner {
-			z-index: 1;
-		}
-
 		#wp-custom-header {
 			position: absolute;
 			height: 100%;

--- a/.dev/sass/layouts/_video-header.scss
+++ b/.dev/sass/layouts/_video-header.scss
@@ -1,6 +1,7 @@
 .site-header.video-header {
 
 	+.main-navigation-container +.hero {
+		overflow: hidden;
 		background-color: #000;
 		color: #000;
 		position: relative;
@@ -11,9 +12,12 @@
 
 		#wp-custom-header {
 			position: absolute;
-			height: 100%;
+			height: 100vh;
 			top: 0;
 			left: 0;
+			right: 0;
+			bottom: 0;
+			margin: auto;
 
 			img {
 				display: none;
@@ -22,10 +26,13 @@
 
 		#wp-custom-header-video-button {
 			position: absolute;
-			bottom: 0.5em;
+			top: 72vh;
 			right: 1em;
 			opacity: 0.5;
-			z-index: 11;
+
+			@media #{$medium-only} {
+				top: 68vh;
+			}
 		}
 
 		iframe#wp-custom-header-video {

--- a/.dev/sass/layouts/_video-header.scss
+++ b/.dev/sass/layouts/_video-header.scss
@@ -27,6 +27,10 @@
 			opacity: 0.5;
 			font-size: 1rem;
 			padding: 0.65em .85em;
+
+			@media #{$medium-down} {
+				bottom: 25vh;
+			}
 		}
 
 		iframe#wp-custom-header-video {

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  *
  * @var string
  */
-define( 'PRIMER_CHILD_VERSION', '1.1.0' );
+define( 'PRIMER_CHILD_VERSION', '1.0.0' );
 
 /**
  * Move some elements around.

--- a/functions.php
+++ b/functions.php
@@ -27,7 +27,7 @@ function scribbles_move_elements() {
 	add_action( 'primer_before_site_navigation', 'scribbles_nav_wrapper_open',    0 );
 	add_action( 'primer_after_site_navigation',  'scribbles_nav_wrapper_close',   400 );
 	add_action( 'primer_after_header',           'primer_add_primary_navigation', 5 );
-	add_action( 'primer_hero',                   'primer_video_header',            3 );
+	add_action( 'primer_hero',                   'primer_video_header',           3 );
 
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {
 

--- a/functions.php
+++ b/functions.php
@@ -17,13 +17,17 @@ define( 'PRIMER_CHILD_VERSION', '1.1.0' );
  */
 function scribbles_move_elements() {
 
-	remove_action( 'primer_header',       'primer_add_hero',       7 );
-	remove_action( 'primer_after_header', 'primer_add_page_title', 12 );
+	remove_action( 'primer_header',                'primer_add_hero',               7 );
+	remove_action( 'primer_after_header',          'primer_add_page_title',         12 );
+	remove_action( 'primer_after_header',          'primer_add_primary_navigation', 11 );
+	remove_action( 'primer_before_header_wrapper', 'primer_video_header',           5 );
 
-	add_action( 'primer_after_header', 'primer_add_hero', 7 );
+	add_action( 'primer_after_header', 'primer_add_hero', 10 );
 
-	add_action( 'primer_before_site_navigation', 'scribbles_nav_wrapper_open', 0 );
-	add_action( 'primer_after_site_navigation', 'scribbles_nav_wrapper_close', 400 );
+	add_action( 'primer_before_site_navigation', 'scribbles_nav_wrapper_open',    0 );
+	add_action( 'primer_after_site_navigation',  'scribbles_nav_wrapper_close',   400 );
+	add_action( 'primer_after_header',           'primer_add_primary_navigation', 5 );
+	add_action( 'primer_hero',                   'primer_video_header',            3 );
 
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1563,8 +1563,6 @@ body.page-template-page-builder-no-header .content-area {
   position: relative; }
   .site-header.video-header + .main-navigation-container + .hero aside {
     position: relative; }
-  .site-header.video-header + .main-navigation-container + .hero .hero-inner {
-    z-index: 1; }
   .site-header.video-header + .main-navigation-container + .hero #wp-custom-header {
     position: absolute;
     height: 100%;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1572,16 +1572,13 @@ body.page-template-page-builder-no-header .content-area {
     left: 0;
     bottom: 0;
     margin: auto; }
-    .site-header.video-header + .main-navigation-container + .hero #wp-custom-header img {
-      display: none; }
   .site-header.video-header + .main-navigation-container + .hero #wp-custom-header-video-button {
     position: absolute;
-    top: 72vh;
+    bottom: 20vh;
     left: 1em;
-    opacity: 0.5; }
-    @media only screen and (min-width: 40.063em) and (max-width: 61.063em) {
-      .site-header.video-header + .main-navigation-container + .hero #wp-custom-header-video-button {
-        top: 68vh; } }
+    opacity: 0.5;
+    font-size: 1rem;
+    padding: 0.65em .85em; }
   .site-header.video-header + .main-navigation-container + .hero iframe#wp-custom-header-video {
     height: 100%; }
 
@@ -1594,6 +1591,8 @@ body.page-template-page-builder-no-header .content-area {
   background-position: top center;
   background-repeat: no-repeat;
   z-index: 0; }
+  .hero #wp-custom-header img {
+    display: none; }
   .hero .hero-inner {
     max-width: 1100px;
     margin-right: auto;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1557,48 +1557,32 @@ body.page-template-page-builder-no-header .content-area {
 /*--------------------------------------------------------------
 # Header
 --------------------------------------------------------------*/
+.site-header.video-header + .main-navigation-container + .hero {
+  background-color: #000;
+  color: #000;
+  position: relative; }
+  .site-header.video-header + .main-navigation-container + .hero aside {
+    position: relative; }
+  .site-header.video-header + .main-navigation-container + .hero .hero-inner {
+    z-index: 1; }
+  .site-header.video-header + .main-navigation-container + .hero #wp-custom-header {
+    position: absolute;
+    height: 100%;
+    top: 0;
+    right: 0; }
+    .site-header.video-header + .main-navigation-container + .hero #wp-custom-header img {
+      display: none; }
+  .site-header.video-header + .main-navigation-container + .hero #wp-custom-header-video-button {
+    position: absolute;
+    bottom: 0.5em;
+    left: 1em;
+    opacity: 0.5;
+    z-index: 11; }
+  .site-header.video-header + .main-navigation-container + .hero iframe#wp-custom-header-video {
+    height: 100%; }
+
 .site-header {
   position: relative; }
-  .site-header.video-header + .main-navigation-container + .hero {
-    background-color: #000;
-    color: #000;
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -moz-box;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-box-align: center;
-    -webkit-align-items: center;
-    -moz-box-align: center;
-    -ms-flex-align: center;
-    align-items: center;
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: reverse;
-    -webkit-flex-direction: row-reverse;
-    -moz-box-orient: horizontal;
-    -moz-box-direction: reverse;
-    -ms-flex-direction: row-reverse;
-    flex-direction: row-reverse;
-    position: relative; }
-    .site-header.video-header + .main-navigation-container + .hero aside {
-      position: relative; }
-    .site-header.video-header + .main-navigation-container + .hero .hero-inner {
-      z-index: 1; }
-    .site-header.video-header + .main-navigation-container + .hero #wp-custom-header {
-      position: absolute;
-      height: 100%;
-      top: 0;
-      right: 0; }
-      .site-header.video-header + .main-navigation-container + .hero #wp-custom-header img {
-        display: none; }
-    .site-header.video-header + .main-navigation-container + .hero #wp-custom-header-video-button {
-      position: absolute;
-      bottom: 0.5em;
-      left: 1em;
-      opacity: 0.5;
-      z-index: 11; }
-    .site-header.video-header + .main-navigation-container + .hero iframe#wp-custom-header-video {
-      height: 100%; }
 
 .hero {
   -webkit-background-size: cover;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1558,6 +1558,7 @@ body.page-template-page-builder-no-header .content-area {
 # Header
 --------------------------------------------------------------*/
 .site-header.video-header + .main-navigation-container + .hero {
+  overflow: hidden;
   background-color: #000;
   color: #000;
   position: relative; }
@@ -1565,17 +1566,22 @@ body.page-template-page-builder-no-header .content-area {
     position: relative; }
   .site-header.video-header + .main-navigation-container + .hero #wp-custom-header {
     position: absolute;
-    height: 100%;
+    height: 100vh;
     top: 0;
-    right: 0; }
+    right: 0;
+    left: 0;
+    bottom: 0;
+    margin: auto; }
     .site-header.video-header + .main-navigation-container + .hero #wp-custom-header img {
       display: none; }
   .site-header.video-header + .main-navigation-container + .hero #wp-custom-header-video-button {
     position: absolute;
-    bottom: 0.5em;
+    top: 72vh;
     left: 1em;
-    opacity: 0.5;
-    z-index: 11; }
+    opacity: 0.5; }
+    @media only screen and (min-width: 40.063em) and (max-width: 61.063em) {
+      .site-header.video-header + .main-navigation-container + .hero #wp-custom-header-video-button {
+        top: 68vh; } }
   .site-header.video-header + .main-navigation-container + .hero iframe#wp-custom-header-video {
     height: 100%; }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1579,6 +1579,9 @@ body.page-template-page-builder-no-header .content-area {
     opacity: 0.5;
     font-size: 1rem;
     padding: 0.65em .85em; }
+    @media only screen and (max-width: 61.063em) {
+      .site-header.video-header + .main-navigation-container + .hero #wp-custom-header-video-button {
+        bottom: 25vh; } }
   .site-header.video-header + .main-navigation-container + .hero iframe#wp-custom-header-video {
     height: 100%; }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1559,6 +1559,46 @@ body.page-template-page-builder-no-header .content-area {
 --------------------------------------------------------------*/
 .site-header {
   position: relative; }
+  .site-header.video-header + .main-navigation-container + .hero {
+    background-color: #000;
+    color: #000;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+    -webkit-align-items: center;
+    -moz-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: reverse;
+    -webkit-flex-direction: row-reverse;
+    -moz-box-orient: horizontal;
+    -moz-box-direction: reverse;
+    -ms-flex-direction: row-reverse;
+    flex-direction: row-reverse;
+    position: relative; }
+    .site-header.video-header + .main-navigation-container + .hero aside {
+      position: relative; }
+    .site-header.video-header + .main-navigation-container + .hero .hero-inner {
+      z-index: 1; }
+    .site-header.video-header + .main-navigation-container + .hero #wp-custom-header {
+      position: absolute;
+      height: 100%;
+      top: 0;
+      right: 0; }
+      .site-header.video-header + .main-navigation-container + .hero #wp-custom-header img {
+        display: none; }
+    .site-header.video-header + .main-navigation-container + .hero #wp-custom-header-video-button {
+      position: absolute;
+      bottom: 0.5em;
+      left: 1em;
+      opacity: 0.5;
+      z-index: 11; }
+    .site-header.video-header + .main-navigation-container + .hero iframe#wp-custom-header-video {
+      height: 100%; }
 
 .hero {
   -webkit-background-size: cover;
@@ -1684,7 +1724,7 @@ body.no-max-width .hero-inner {
   font-size: 3em; }
 
 body.custom-header-image .hero {
-  text-shadow: -1px -1px 30px rgba(0, 0, 0, 0.5); }
+  text-shadow: -1px 1px 30px rgba(0, 0, 0, 0.5); }
 
 .header-image img {
   display: block; }

--- a/style.css
+++ b/style.css
@@ -1572,16 +1572,13 @@ body.page-template-page-builder-no-header .content-area {
     right: 0;
     bottom: 0;
     margin: auto; }
-    .site-header.video-header + .main-navigation-container + .hero #wp-custom-header img {
-      display: none; }
   .site-header.video-header + .main-navigation-container + .hero #wp-custom-header-video-button {
     position: absolute;
-    top: 72vh;
+    bottom: 20vh;
     right: 1em;
-    opacity: 0.5; }
-    @media only screen and (min-width: 40.063em) and (max-width: 61.063em) {
-      .site-header.video-header + .main-navigation-container + .hero #wp-custom-header-video-button {
-        top: 68vh; } }
+    opacity: 0.5;
+    font-size: 1rem;
+    padding: 0.65em .85em; }
   .site-header.video-header + .main-navigation-container + .hero iframe#wp-custom-header-video {
     height: 100%; }
 
@@ -1594,6 +1591,8 @@ body.page-template-page-builder-no-header .content-area {
   background-position: top center;
   background-repeat: no-repeat;
   z-index: 0; }
+  .hero #wp-custom-header img {
+    display: none; }
   .hero .hero-inner {
     max-width: 1100px;
     margin-left: auto;

--- a/style.css
+++ b/style.css
@@ -1558,6 +1558,7 @@ body.page-template-page-builder-no-header .content-area {
 # Header
 --------------------------------------------------------------*/
 .site-header.video-header + .main-navigation-container + .hero {
+  overflow: hidden;
   background-color: #000;
   color: #000;
   position: relative; }
@@ -1565,17 +1566,22 @@ body.page-template-page-builder-no-header .content-area {
     position: relative; }
   .site-header.video-header + .main-navigation-container + .hero #wp-custom-header {
     position: absolute;
-    height: 100%;
+    height: 100vh;
     top: 0;
-    left: 0; }
+    left: 0;
+    right: 0;
+    bottom: 0;
+    margin: auto; }
     .site-header.video-header + .main-navigation-container + .hero #wp-custom-header img {
       display: none; }
   .site-header.video-header + .main-navigation-container + .hero #wp-custom-header-video-button {
     position: absolute;
-    bottom: 0.5em;
+    top: 72vh;
     right: 1em;
-    opacity: 0.5;
-    z-index: 11; }
+    opacity: 0.5; }
+    @media only screen and (min-width: 40.063em) and (max-width: 61.063em) {
+      .site-header.video-header + .main-navigation-container + .hero #wp-custom-header-video-button {
+        top: 68vh; } }
   .site-header.video-header + .main-navigation-container + .hero iframe#wp-custom-header-video {
     height: 100%; }
 

--- a/style.css
+++ b/style.css
@@ -1563,8 +1563,6 @@ body.page-template-page-builder-no-header .content-area {
   position: relative; }
   .site-header.video-header + .main-navigation-container + .hero aside {
     position: relative; }
-  .site-header.video-header + .main-navigation-container + .hero .hero-inner {
-    z-index: 1; }
   .site-header.video-header + .main-navigation-container + .hero #wp-custom-header {
     position: absolute;
     height: 100%;

--- a/style.css
+++ b/style.css
@@ -1559,6 +1559,46 @@ body.page-template-page-builder-no-header .content-area {
 --------------------------------------------------------------*/
 .site-header {
   position: relative; }
+  .site-header.video-header + .main-navigation-container + .hero {
+    background-color: #000;
+    color: #000;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+    -webkit-align-items: center;
+    -moz-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: reverse;
+    -webkit-flex-direction: row-reverse;
+    -moz-box-orient: horizontal;
+    -moz-box-direction: reverse;
+    -ms-flex-direction: row-reverse;
+    flex-direction: row-reverse;
+    position: relative; }
+    .site-header.video-header + .main-navigation-container + .hero aside {
+      position: relative; }
+    .site-header.video-header + .main-navigation-container + .hero .hero-inner {
+      z-index: 1; }
+    .site-header.video-header + .main-navigation-container + .hero #wp-custom-header {
+      position: absolute;
+      height: 100%;
+      top: 0;
+      left: 0; }
+      .site-header.video-header + .main-navigation-container + .hero #wp-custom-header img {
+        display: none; }
+    .site-header.video-header + .main-navigation-container + .hero #wp-custom-header-video-button {
+      position: absolute;
+      bottom: 0.5em;
+      right: 1em;
+      opacity: 0.5;
+      z-index: 11; }
+    .site-header.video-header + .main-navigation-container + .hero iframe#wp-custom-header-video {
+      height: 100%; }
 
 .hero {
   -webkit-background-size: cover;

--- a/style.css
+++ b/style.css
@@ -1579,6 +1579,9 @@ body.page-template-page-builder-no-header .content-area {
     opacity: 0.5;
     font-size: 1rem;
     padding: 0.65em .85em; }
+    @media only screen and (max-width: 61.063em) {
+      .site-header.video-header + .main-navigation-container + .hero #wp-custom-header-video-button {
+        bottom: 25vh; } }
   .site-header.video-header + .main-navigation-container + .hero iframe#wp-custom-header-video {
     height: 100%; }
 

--- a/style.css
+++ b/style.css
@@ -1557,48 +1557,32 @@ body.page-template-page-builder-no-header .content-area {
 /*--------------------------------------------------------------
 # Header
 --------------------------------------------------------------*/
+.site-header.video-header + .main-navigation-container + .hero {
+  background-color: #000;
+  color: #000;
+  position: relative; }
+  .site-header.video-header + .main-navigation-container + .hero aside {
+    position: relative; }
+  .site-header.video-header + .main-navigation-container + .hero .hero-inner {
+    z-index: 1; }
+  .site-header.video-header + .main-navigation-container + .hero #wp-custom-header {
+    position: absolute;
+    height: 100%;
+    top: 0;
+    left: 0; }
+    .site-header.video-header + .main-navigation-container + .hero #wp-custom-header img {
+      display: none; }
+  .site-header.video-header + .main-navigation-container + .hero #wp-custom-header-video-button {
+    position: absolute;
+    bottom: 0.5em;
+    right: 1em;
+    opacity: 0.5;
+    z-index: 11; }
+  .site-header.video-header + .main-navigation-container + .hero iframe#wp-custom-header-video {
+    height: 100%; }
+
 .site-header {
   position: relative; }
-  .site-header.video-header + .main-navigation-container + .hero {
-    background-color: #000;
-    color: #000;
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -moz-box;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-box-align: center;
-    -webkit-align-items: center;
-    -moz-box-align: center;
-    -ms-flex-align: center;
-    align-items: center;
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: reverse;
-    -webkit-flex-direction: row-reverse;
-    -moz-box-orient: horizontal;
-    -moz-box-direction: reverse;
-    -ms-flex-direction: row-reverse;
-    flex-direction: row-reverse;
-    position: relative; }
-    .site-header.video-header + .main-navigation-container + .hero aside {
-      position: relative; }
-    .site-header.video-header + .main-navigation-container + .hero .hero-inner {
-      z-index: 1; }
-    .site-header.video-header + .main-navigation-container + .hero #wp-custom-header {
-      position: absolute;
-      height: 100%;
-      top: 0;
-      left: 0; }
-      .site-header.video-header + .main-navigation-container + .hero #wp-custom-header img {
-        display: none; }
-    .site-header.video-header + .main-navigation-container + .hero #wp-custom-header-video-button {
-      position: absolute;
-      bottom: 0.5em;
-      right: 1em;
-      opacity: 0.5;
-      z-index: 11; }
-    .site-header.video-header + .main-navigation-container + .hero iframe#wp-custom-header-video {
-      height: 100%; }
 
 .hero {
   -webkit-background-size: cover;


### PR DESCRIPTION
Since WordPress 4.7, Video Headers have been possible. This PR introduces styles to accommodate video headers within Scribbles.

![Example](https://cldup.com/sYZFN7Qons.png)