### PR TITLE
Prevent text overflow on add to cart buttons

### DIFF
--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -178,6 +178,7 @@ body.woocommerce-cart {
 	width: 100%;
 	font-size: 16px;
 	text-align: center;
+	white-space: normal;
 }
 
 @media #{$small-only} {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1684,7 +1684,7 @@ body.no-max-width .hero-inner {
   font-size: 3em; }
 
 body.custom-header-image .hero {
-  text-shadow: -1px -1px 30px rgba(0, 0, 0, 0.5); }
+  text-shadow: -1px 1px 30px rgba(0, 0, 0, 0.5); }
 
 .header-image img {
   display: block; }
@@ -2352,7 +2352,8 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;
   font-size: 16px;
-  text-align: center; }
+  text-align: center;
+  white-space: normal; }
 
 @media only screen and (max-width: 40.063em) {
   .primer-wc-cart-menu .primer-wc-cart-sub-menu {

--- a/style.css
+++ b/style.css
@@ -2352,7 +2352,8 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;
   font-size: 16px;
-  text-align: center; }
+  text-align: center;
+  white-space: normal; }
 
 @media only screen and (max-width: 40.063em) {
   .primer-wc-cart-menu .primer-wc-cart-sub-menu {


### PR DESCRIPTION
Prevent text overflows on 'Add to Cart' buttons, especially on i10n sites.

Also relevant on smaller screens when in the site customizer.

![Example](https://cldup.com/kMP-k9ZCiA.png)