### PR TITLE
WordPress 4.9.6 Support

### DIFF
--- a/.dev/sass/layouts/_comments.scss
+++ b/.dev/sass/layouts/_comments.scss
@@ -19,6 +19,21 @@
 	textarea {
 		width: 100%;
 	}
+
+	.comment-form-cookies-consent {
+		display: flex;
+		line-height: 16px;
+
+		#wp-comment-cookies-consent {
+			display: inline;
+			width: auto;
+			margin: 0 10px 0 0;
+
+			@media #{$small-only} {
+				margin-top: 2px;
+			}
+		}
+	}
 }
 
 .comment-list {

--- a/.dev/sass/layouts/_footer.scss
+++ b/.dev/sass/layouts/_footer.scss
@@ -84,9 +84,17 @@ body.no-max-width .footer-widget-area {
 .site-info-wrapper {
 	padding: 1.5em 0;
 	background-color: $color__footer-bg;
+	text-align: none;
 
 	.site-info {
 		@include container($container-size);
+	}
+
+	.privacy-policy-link {
+		display: inline-block;
+		font-size: 75%;
+		line-height: 1.2;
+		margin: 0 1.38889%;
 	}
 
 	.site-info-text {
@@ -103,10 +111,18 @@ body.no-max-width .footer-widget-area {
 	}
 
 	@media #{$small-only} {
+		text-align: center;
 
 		.social-menu {
 			@include span(12);
+			text-align: center;
 
+			+ .privacy-policy-link {
+				padding-top: 3em;
+			}
+		}
+
+		.privacy-policy-link {
 			text-align: center;
 		}
 	}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -185,7 +185,7 @@ module.exports = function( grunt ) {
 			},
 			sass: {
 				files: '.dev/sass/**/*.scss',
-				tasks: [ 'sass', 'autoprefixer', 'cssjanus' ]
+				tasks: [ 'sass', 'replace:charset', 'autoprefixer', 'cssjanus' ]
 			}
 		},
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,4932 @@
+{
+  "name": "scribbles",
+  "version": "1.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/abbrev/-/abbrev-1.1.1.tgz?dl=https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
+      "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/amdefine/-/amdefine-1.0.1.tgz?dl=https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ansi-escapes/-/ansi-escapes-1.4.0.tgz?dl=https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ansi-gray/-/ansi-gray-0.1.1.tgz?dl=https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ansi-regex/-/ansi-regex-2.1.1.tgz?dl=https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ansi-styles/-/ansi-styles-2.2.1.tgz?dl=https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ansi-wrap/-/ansi-wrap-0.1.0.tgz?dl=https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/aproba/-/aproba-1.2.0.tgz?dl=https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
+      "dev": true
+    },
+    "archive-type": {
+      "version": "3.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/archive-type/-/archive-type-3.2.0.tgz?dl=https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz",
+      "integrity": "sha1-nNnABpV+vpX62tW9YJiUKoE3N/Y=",
+      "dev": true,
+      "requires": {
+        "file-type": "^3.1.0"
+      }
+    },
+    "are-we-there-yet": {
+      "version": "1.1.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz?dl=https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "dev": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/argparse/-/argparse-1.0.10.tgz?dl=https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/arr-diff/-/arr-diff-2.0.0.tgz?dl=https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.0.1"
+      }
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/arr-flatten/-/arr-flatten-1.1.0.tgz?dl=https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "dev": true
+    },
+    "array-differ": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/array-differ/-/array-differ-1.0.0.tgz?dl=https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+      "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/array-find-index/-/array-find-index-1.0.2.tgz?dl=https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/array-union/-/array-union-1.0.2.tgz?dl=https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/array-uniq/-/array-uniq-1.0.3.tgz?dl=https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/array-unique/-/array-unique-0.2.1.tgz?dl=https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/arrify/-/arrify-1.0.1.tgz?dl=https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/asn1/-/asn1-0.2.3.tgz?dl=https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/assert-plus/-/assert-plus-0.2.0.tgz?dl=https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/async/-/async-1.5.2.tgz?dl=https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "async-each-series": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/async-each-series/-/async-each-series-1.1.0.tgz?dl=https://registry.npmjs.org/async-each-series/-/async-each-series-1.1.0.tgz",
+      "integrity": "sha1-9C/YFV048hpbjqB8KOBj7RcAsTg=",
+      "dev": true
+    },
+    "async-foreach": {
+      "version": "0.1.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/async-foreach/-/async-foreach-0.1.3.tgz?dl=https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/asynckit/-/asynckit-0.4.0.tgz?dl=https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "autoprefixer-core": {
+      "version": "5.2.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz?dl=https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
+      "integrity": "sha1-5kDEFK5Bmq4hwa1DyOoPPbgqVm0=",
+      "dev": true,
+      "requires": {
+        "browserslist": "~0.4.0",
+        "caniuse-db": "^1.0.30000214",
+        "num2fraction": "^1.1.0",
+        "postcss": "~4.1.12"
+      }
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/aws-sign2/-/aws-sign2-0.6.0.tgz?dl=https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.7.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/aws4/-/aws4-1.7.0.tgz?dl=https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha1-1NDpudv8p3vwjusKikcVUP454ok=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/balanced-match/-/balanced-match-1.0.0.tgz?dl=https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz?dl=https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "beeper": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/beeper/-/beeper-1.1.1.tgz?dl=https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+      "dev": true
+    },
+    "bin-build": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/bin-build/-/bin-build-2.2.0.tgz?dl=https://registry.npmjs.org/bin-build/-/bin-build-2.2.0.tgz",
+      "integrity": "sha1-EfjdYfcP/Por3KpbRvXo/t1CIcw=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "archive-type": "^3.0.1",
+        "decompress": "^3.0.0",
+        "download": "^4.1.2",
+        "exec-series": "^1.0.0",
+        "rimraf": "^2.2.6",
+        "tempfile": "^1.0.0",
+        "url-regex": "^3.0.0"
+      }
+    },
+    "bin-check": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/bin-check/-/bin-check-2.0.0.tgz?dl=https://registry.npmjs.org/bin-check/-/bin-check-2.0.0.tgz",
+      "integrity": "sha1-hvjm9CU4k99g3DFpV/WvAqywWTA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "executable": "^1.0.0"
+      }
+    },
+    "bin-version": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/bin-version/-/bin-version-1.0.4.tgz?dl=https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
+      "integrity": "sha1-nrSY7m/Xb3q5p8FgQ2+JV5Q1144=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "find-versions": "^1.0.0"
+      }
+    },
+    "bin-version-check": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/bin-version-check/-/bin-version-check-2.1.0.tgz?dl=https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
+      "integrity": "sha1-5OXfKQuQaffRETJAMe/BP90RpbA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "bin-version": "^1.0.0",
+        "minimist": "^1.1.0",
+        "semver": "^4.0.3",
+        "semver-truncate": "^1.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "4.3.6",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/semver/-/semver-4.3.6.tgz?dl=https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "bin-wrapper": {
+      "version": "3.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/bin-wrapper/-/bin-wrapper-3.0.2.tgz?dl=https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-3.0.2.tgz",
+      "integrity": "sha1-Z9MwYmLksaXy+I7iNGT2plVneus=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "bin-check": "^2.0.0",
+        "bin-version-check": "^2.1.0",
+        "download": "^4.0.0",
+        "each-async": "^1.1.1",
+        "lazy-req": "^1.0.0",
+        "os-filter-obj": "^1.0.0"
+      }
+    },
+    "bl": {
+      "version": "1.2.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/bl/-/bl-1.2.2.tgz?dl=https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "integrity": "sha1-oWCRFxcQPAdBDO9j71Gzl8Alr5w=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/block-stream/-/block-stream-0.0.9.tgz?dl=https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.0"
+      }
+    },
+    "body": {
+      "version": "5.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/body/-/body-5.1.0.tgz?dl=https://registry.npmjs.org/body/-/body-5.1.0.tgz",
+      "integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
+      "dev": true,
+      "requires": {
+        "continuable-cache": "^0.3.1",
+        "error": "^7.0.0",
+        "raw-body": "~1.1.0",
+        "safe-json-parse": "~1.0.1"
+      }
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/boom/-/boom-2.10.1.tgz?dl=https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.x.x"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/brace-expansion/-/brace-expansion-1.1.11.tgz?dl=https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/braces/-/braces-1.8.5.tgz?dl=https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "dev": true,
+      "requires": {
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
+      }
+    },
+    "browserslist": {
+      "version": "0.4.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/browserslist/-/browserslist-0.4.0.tgz?dl=https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz",
+      "integrity": "sha1-O9SrkZncG5FQ1NbbpNnTqrvIbdQ=",
+      "dev": true,
+      "requires": {
+        "caniuse-db": "^1.0.30000153"
+      }
+    },
+    "buffer-alloc": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/buffer-alloc/-/buffer-alloc-1.1.0.tgz?dl=https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.1.0.tgz",
+      "integrity": "sha1-BVFNM78WVtNUDGhPZbEgLpDsowM=",
+      "dev": true,
+      "requires": {
+        "buffer-alloc-unsafe": "^0.1.0",
+        "buffer-fill": "^0.1.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/buffer-alloc-unsafe/-/buffer-alloc-unsafe-0.1.1.tgz?dl=https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-0.1.1.tgz",
+      "integrity": "sha1-/+H2dVHdBVc33iUzN7/oU9+rGmo=",
+      "dev": true
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/buffer-crc32/-/buffer-crc32-0.2.13.tgz?dl=https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
+    },
+    "buffer-fill": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/buffer-fill/-/buffer-fill-0.1.1.tgz?dl=https://registry.npmjs.org/buffer-fill/-/buffer-fill-0.1.1.tgz",
+      "integrity": "sha1-dtglxNblDga3ox61IMBNCMwjUHE=",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/buffer-from/-/buffer-from-1.0.0.tgz?dl=https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha1-TLiDLSNhJYmwQG6eKVbBfwb99TE=",
+      "dev": true
+    },
+    "buffer-to-vinyl": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz?dl=https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz",
+      "integrity": "sha1-APFfruOreh3aLN5tkSG//dB7ImI=",
+      "dev": true,
+      "requires": {
+        "file-type": "^3.1.0",
+        "readable-stream": "^2.0.2",
+        "uuid": "^2.0.1",
+        "vinyl": "^1.0.0"
+      }
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/builtin-modules/-/builtin-modules-1.1.1.tgz?dl=https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "bytes": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/bytes/-/bytes-1.0.0.tgz?dl=https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+      "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/camelcase/-/camelcase-2.1.1.tgz?dl=https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/camelcase-keys/-/camelcase-keys-2.1.0.tgz?dl=https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      }
+    },
+    "caniuse-db": {
+      "version": "1.0.30000844",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/caniuse-db/-/caniuse-db-1.0.30000844.tgz?dl=https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000844.tgz",
+      "integrity": "sha1-vKV5jNoraTHWgQDC1p5V+zOMu0E=",
+      "dev": true
+    },
+    "capture-stack-trace": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz?dl=https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/caseless/-/caseless-0.11.0.tgz?dl=https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+      "dev": true
+    },
+    "caw": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/caw/-/caw-1.2.0.tgz?dl=https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
+      "integrity": "sha1-/7Im/n78VHKI3GLuPpcHPCEtEDQ=",
+      "dev": true,
+      "requires": {
+        "get-proxy": "^1.0.1",
+        "is-obj": "^1.0.0",
+        "object-assign": "^3.0.0",
+        "tunnel-agent": "^0.4.0"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/object-assign/-/object-assign-3.0.0.tgz?dl=https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+          "dev": true
+        }
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/chalk/-/chalk-1.1.3.tgz?dl=https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "clap": {
+      "version": "1.2.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/clap/-/clap-1.2.3.tgz?dl=https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
+      "integrity": "sha1-TzZ0WzIAhJJVf0ZBLWbVDLmbzlE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "^1.1.3"
+      }
+    },
+    "cli": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cli/-/cli-1.0.1.tgz?dl=https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "^7.1.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/glob/-/glob-7.1.2.tgz?dl=https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cli-cursor/-/cli-cursor-1.0.2.tgz?dl=https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^1.0.1"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cli-width/-/cli-width-2.2.0.tgz?dl=https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cliui/-/cliui-3.2.0.tgz?dl=https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
+      }
+    },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/clone/-/clone-1.0.4.tgz?dl=https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true
+    },
+    "clone-stats": {
+      "version": "0.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/clone-stats/-/clone-stats-0.0.1.tgz?dl=https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+      "dev": true
+    },
+    "co": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/co/-/co-3.1.0.tgz?dl=https://registry.npmjs.org/co/-/co-3.1.0.tgz",
+      "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g=",
+      "dev": true
+    },
+    "coa": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/coa/-/coa-1.0.4.tgz?dl=https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+      "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "q": "^1.1.2"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/code-point-at/-/code-point-at-1.1.0.tgz?dl=https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "coffeescript": {
+      "version": "1.10.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/coffeescript/-/coffeescript-1.10.0.tgz?dl=https://registry.npmjs.org/coffeescript/-/coffeescript-1.10.0.tgz",
+      "integrity": "sha1-56qDAZF+9iGzXYo580jc3R234z4=",
+      "dev": true
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/color-support/-/color-support-1.1.3.tgz?dl=https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha1-k4NDeaHMmgxh+C9S8NBDIiUb1aI=",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/colors/-/colors-1.1.2.tgz?dl=https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/combined-stream/-/combined-stream-1.0.6.tgz?dl=https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.8.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/commander/-/commander-2.8.1.tgz?dl=https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+      "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": ">= 1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/concat-map/-/concat-map-0.0.1.tgz?dl=https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/concat-stream/-/concat-stream-1.6.2.tgz?dl=https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/console-browserify/-/console-browserify-1.1.0.tgz?dl=https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "^0.1.4"
+      }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/console-control-strings/-/console-control-strings-1.1.0.tgz?dl=https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
+    },
+    "console-stream": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/console-stream/-/console-stream-0.1.1.tgz?dl=https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz",
+      "integrity": "sha1-oJX+B7IEZZVfL6/Si11yvM2UnUQ=",
+      "dev": true,
+      "optional": true
+    },
+    "continuable-cache": {
+      "version": "0.3.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/continuable-cache/-/continuable-cache-0.3.1.tgz?dl=https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
+      "integrity": "sha1-vXJ6f67XfnH/OYWskzUakSczrQ8=",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.5.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/convert-source-map/-/convert-source-map-1.5.1.tgz?dl=https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/core-util-is/-/core-util-is-1.0.2.tgz?dl=https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "create-error-class": {
+      "version": "3.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/create-error-class/-/create-error-class-3.0.2.tgz?dl=https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true,
+      "requires": {
+        "capture-stack-trace": "^1.0.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cross-spawn/-/cross-spawn-3.0.1.tgz?dl=https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+      "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "which": "^1.2.9"
+      }
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cryptiles/-/cryptiles-2.0.5.tgz?dl=https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true,
+      "requires": {
+        "boom": "2.x.x"
+      }
+    },
+    "cssjanus": {
+      "version": "1.2.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/cssjanus/-/cssjanus-1.2.2.tgz?dl=https://registry.npmjs.org/cssjanus/-/cssjanus-1.2.2.tgz",
+      "integrity": "sha1-w2jMOSz3tOAQzfE+l+r87tCHKjc=",
+      "dev": true
+    },
+    "csso": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/csso/-/csso-2.0.0.tgz?dl=https://registry.npmjs.org/csso/-/csso-2.0.0.tgz",
+      "integrity": "sha1-F4tDpEYhIhwndWCG9THgL0KQDug=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "clap": "^1.0.9",
+        "source-map": "^0.5.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/source-map/-/source-map-0.5.7.tgz?dl=https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/currently-unhandled/-/currently-unhandled-0.4.1.tgz?dl=https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/dashdash/-/dashdash-1.14.1.tgz?dl=https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/assert-plus/-/assert-plus-1.0.0.tgz?dl=https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/date-now/-/date-now-0.1.4.tgz?dl=https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
+    },
+    "dateformat": {
+      "version": "1.0.12",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/dateformat/-/dateformat-1.0.12.tgz?dl=https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+      "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1",
+        "meow": "^3.3.0"
+      }
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/debug/-/debug-3.1.0.tgz?dl=https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/decamelize/-/decamelize-1.2.0.tgz?dl=https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decompress": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/decompress/-/decompress-3.0.0.tgz?dl=https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz",
+      "integrity": "sha1-rx3VDQbjv8QyRh033hGzjA2ZG+0=",
+      "dev": true,
+      "requires": {
+        "buffer-to-vinyl": "^1.0.0",
+        "concat-stream": "^1.4.6",
+        "decompress-tar": "^3.0.0",
+        "decompress-tarbz2": "^3.0.0",
+        "decompress-targz": "^3.0.0",
+        "decompress-unzip": "^3.0.0",
+        "stream-combiner2": "^1.1.1",
+        "vinyl-assign": "^1.0.1",
+        "vinyl-fs": "^2.2.0"
+      }
+    },
+    "decompress-tar": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/decompress-tar/-/decompress-tar-3.1.0.tgz?dl=https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
+      "integrity": "sha1-IXx4n5uURQ76rcXF5TeXj8MzxGY=",
+      "dev": true,
+      "requires": {
+        "is-tar": "^1.0.0",
+        "object-assign": "^2.0.0",
+        "strip-dirs": "^1.0.0",
+        "tar-stream": "^1.1.1",
+        "through2": "^0.6.1",
+        "vinyl": "^0.4.3"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "0.2.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/clone/-/clone-0.2.0.tgz?dl=https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/object-assign/-/object-assign-2.1.1.tgz?dl=https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+          "dev": true
+        },
+        "vinyl": {
+          "version": "0.4.6",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/vinyl/-/vinyl-0.4.6.tgz?dl=https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+          "dev": true,
+          "requires": {
+            "clone": "^0.2.0",
+            "clone-stats": "^0.0.1"
+          }
+        }
+      }
+    },
+    "decompress-tarbz2": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz?dl=https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
+      "integrity": "sha1-iyOTVoE1X58YnYclag+L3ZbZZm0=",
+      "dev": true,
+      "requires": {
+        "is-bzip2": "^1.0.0",
+        "object-assign": "^2.0.0",
+        "seek-bzip": "^1.0.3",
+        "strip-dirs": "^1.0.0",
+        "tar-stream": "^1.1.1",
+        "through2": "^0.6.1",
+        "vinyl": "^0.4.3"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "0.2.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/clone/-/clone-0.2.0.tgz?dl=https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/object-assign/-/object-assign-2.1.1.tgz?dl=https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+          "dev": true
+        },
+        "vinyl": {
+          "version": "0.4.6",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/vinyl/-/vinyl-0.4.6.tgz?dl=https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+          "dev": true,
+          "requires": {
+            "clone": "^0.2.0",
+            "clone-stats": "^0.0.1"
+          }
+        }
+      }
+    },
+    "decompress-targz": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/decompress-targz/-/decompress-targz-3.1.0.tgz?dl=https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
+      "integrity": "sha1-ssE9+YFmJomRtxXWRH9kLpaW9aA=",
+      "dev": true,
+      "requires": {
+        "is-gzip": "^1.0.0",
+        "object-assign": "^2.0.0",
+        "strip-dirs": "^1.0.0",
+        "tar-stream": "^1.1.1",
+        "through2": "^0.6.1",
+        "vinyl": "^0.4.3"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "0.2.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/clone/-/clone-0.2.0.tgz?dl=https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/object-assign/-/object-assign-2.1.1.tgz?dl=https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+          "dev": true
+        },
+        "vinyl": {
+          "version": "0.4.6",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/vinyl/-/vinyl-0.4.6.tgz?dl=https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+          "dev": true,
+          "requires": {
+            "clone": "^0.2.0",
+            "clone-stats": "^0.0.1"
+          }
+        }
+      }
+    },
+    "decompress-unzip": {
+      "version": "3.4.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/decompress-unzip/-/decompress-unzip-3.4.0.tgz?dl=https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz",
+      "integrity": "sha1-YUdbQVIGa74/7hL51inRX+ZHjus=",
+      "dev": true,
+      "requires": {
+        "is-zip": "^1.0.0",
+        "read-all-stream": "^3.0.0",
+        "stat-mode": "^0.2.0",
+        "strip-dirs": "^1.0.0",
+        "through2": "^2.0.0",
+        "vinyl": "^1.0.0",
+        "yauzl": "^2.2.1"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.3",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/through2/-/through2-2.0.3.tgz?dl=https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
+          }
+        }
+      }
+    },
+    "deep-extend": {
+      "version": "0.5.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/deep-extend/-/deep-extend-0.5.1.tgz?dl=https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+      "integrity": "sha1-uJSp3ZDTAj+/HFWjlPuFjrIGbx8=",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/delayed-stream/-/delayed-stream-1.0.0.tgz?dl=https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/delegates/-/delegates-1.0.0.tgz?dl=https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
+    },
+    "detect-file": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/detect-file/-/detect-file-0.1.0.tgz?dl=https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
+      "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
+      "dev": true,
+      "requires": {
+        "fs-exists-sync": "^0.1.0"
+      }
+    },
+    "diff": {
+      "version": "1.3.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/diff/-/diff-1.3.2.tgz?dl=https://registry.npmjs.org/diff/-/diff-1.3.2.tgz",
+      "integrity": "sha1-/Qeh8fiRUZ2ZBaTJqJ3PWnC2YDc=",
+      "dev": true
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/dom-serializer/-/dom-serializer-0.1.0.tgz?dl=https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/domelementtype/-/domelementtype-1.1.3.tgz?dl=https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
+        },
+        "entities": {
+          "version": "1.1.1",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/entities/-/entities-1.1.1.tgz?dl=https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/domelementtype/-/domelementtype-1.3.0.tgz?dl=https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/domhandler/-/domhandler-2.3.0.tgz?dl=https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/domutils/-/domutils-1.5.1.tgz?dl=https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "download": {
+      "version": "4.4.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/download/-/download-4.4.3.tgz?dl=https://registry.npmjs.org/download/-/download-4.4.3.tgz",
+      "integrity": "sha1-qlX9rTktldS2jowr4D4MKqIbqaw=",
+      "dev": true,
+      "requires": {
+        "caw": "^1.0.1",
+        "concat-stream": "^1.4.7",
+        "each-async": "^1.0.0",
+        "filenamify": "^1.0.1",
+        "got": "^5.0.0",
+        "gulp-decompress": "^1.2.0",
+        "gulp-rename": "^1.2.0",
+        "is-url": "^1.2.0",
+        "object-assign": "^4.0.1",
+        "read-all-stream": "^3.0.0",
+        "readable-stream": "^2.0.2",
+        "stream-combiner2": "^1.1.1",
+        "vinyl": "^1.0.0",
+        "vinyl-fs": "^2.2.0",
+        "ware": "^1.2.0"
+      }
+    },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/duplexer2/-/duplexer2-0.1.4.tgz?dl=https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "duplexify": {
+      "version": "3.6.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/duplexify/-/duplexify-3.6.0.tgz?dl=https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha1-WSkD9dgLONA3IgVBJk1poZj7NBA=",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "each-async": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/each-async/-/each-async-1.1.1.tgz?dl=https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+      "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
+      "dev": true,
+      "requires": {
+        "onetime": "^1.0.0",
+        "set-immediate-shim": "^1.0.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz?dl=https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsbn": "~0.1.0"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/end-of-stream/-/end-of-stream-1.4.1.tgz?dl=https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "entities": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/entities/-/entities-1.0.0.tgz?dl=https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+      "dev": true
+    },
+    "error": {
+      "version": "7.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/error/-/error-7.0.2.tgz?dl=https://registry.npmjs.org/error/-/error-7.0.2.tgz",
+      "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
+      "dev": true,
+      "requires": {
+        "string-template": "~0.2.1",
+        "xtend": "~4.0.0"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/error-ex/-/error-ex-1.3.1.tgz?dl=https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "es6-promise": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/es6-promise/-/es6-promise-2.3.0.tgz?dl=https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+      "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz?dl=https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/esprima/-/esprima-2.7.3.tgz?dl=https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true
+    },
+    "eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/eventemitter2/-/eventemitter2-0.4.14.tgz?dl=https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+      "dev": true
+    },
+    "exec-buffer": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/exec-buffer/-/exec-buffer-2.0.1.tgz?dl=https://registry.npmjs.org/exec-buffer/-/exec-buffer-2.0.1.tgz",
+      "integrity": "sha1-ACijG+CxRgth0HX5avRYO54zXqA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "rimraf": "^2.2.6",
+        "tempfile": "^1.0.0"
+      }
+    },
+    "exec-series": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/exec-series/-/exec-series-1.0.3.tgz?dl=https://registry.npmjs.org/exec-series/-/exec-series-1.0.3.tgz",
+      "integrity": "sha1-bSV6m+rEgqhyx3g7yGFYOfx3FDo=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "async-each-series": "^1.1.0",
+        "object-assign": "^4.1.0"
+      }
+    },
+    "executable": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/executable/-/executable-1.1.0.tgz?dl=https://registry.npmjs.org/executable/-/executable-1.1.0.tgz",
+      "integrity": "sha1-h3mA6REvM5EGbaNyZd562ENKtNk=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "meow": "^3.1.0"
+      }
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/exit/-/exit-0.1.2.tgz?dl=https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/exit-hook/-/exit-hook-1.1.1.tgz?dl=https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/expand-brackets/-/expand-brackets-0.1.5.tgz?dl=https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "dev": true,
+      "requires": {
+        "is-posix-bracket": "^0.1.0"
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/expand-range/-/expand-range-1.8.2.tgz?dl=https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
+      "requires": {
+        "fill-range": "^2.1.0"
+      }
+    },
+    "expand-tilde": {
+      "version": "1.2.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/expand-tilde/-/expand-tilde-1.2.2.tgz?dl=https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+      "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.1"
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/extend/-/extend-3.0.1.tgz?dl=https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/extend-shallow/-/extend-shallow-2.0.1.tgz?dl=https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "requires": {
+        "is-extendable": "^0.1.0"
+      }
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/extglob/-/extglob-0.3.2.tgz?dl=https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^1.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-extglob/-/is-extglob-1.0.0.tgz?dl=https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        }
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/extsprintf/-/extsprintf-1.3.0.tgz?dl=https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fancy-log": {
+      "version": "1.3.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fancy-log/-/fancy-log-1.3.2.tgz?dl=https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+      "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+      "dev": true,
+      "requires": {
+        "ansi-gray": "^0.1.1",
+        "color-support": "^1.1.3",
+        "time-stamp": "^1.0.0"
+      }
+    },
+    "faye-websocket": {
+      "version": "0.10.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/faye-websocket/-/faye-websocket-0.10.0.tgz?dl=https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+      "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+      "dev": true,
+      "requires": {
+        "websocket-driver": ">=0.5.1"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fd-slicer/-/fd-slicer-1.0.1.tgz?dl=https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/figures/-/figures-1.7.0.tgz?dl=https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      }
+    },
+    "file-sync-cmp": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz?dl=https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
+      "integrity": "sha1-peeo/7+kk7Q7kju9TKiaU7Y7YSs=",
+      "dev": true
+    },
+    "file-type": {
+      "version": "3.9.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/file-type/-/file-type-3.9.0.tgz?dl=https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+      "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
+      "dev": true
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/filename-regex/-/filename-regex-2.0.1.tgz?dl=https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "dev": true
+    },
+    "filename-reserved-regex": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz?dl=https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
+      "integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
+      "dev": true
+    },
+    "filenamify": {
+      "version": "1.2.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/filenamify/-/filenamify-1.2.1.tgz?dl=https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
+      "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
+      "dev": true,
+      "requires": {
+        "filename-reserved-regex": "^1.0.0",
+        "strip-outer": "^1.0.0",
+        "trim-repeated": "^1.0.0"
+      }
+    },
+    "fill-range": {
+      "version": "2.2.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fill-range/-/fill-range-2.2.4.tgz?dl=https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha1-6x53OrsFbc2N8r/favWbizqTZWU=",
+      "dev": true,
+      "requires": {
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/find-up/-/find-up-1.1.2.tgz?dl=https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "find-versions": {
+      "version": "1.2.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/find-versions/-/find-versions-1.2.1.tgz?dl=https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz",
+      "integrity": "sha1-y96fEuOFdaCvG+G5osXV/Y8Ya2I=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "array-uniq": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "meow": "^3.5.0",
+        "semver-regex": "^1.0.0"
+      }
+    },
+    "findup-sync": {
+      "version": "0.3.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/findup-sync/-/findup-sync-0.3.0.tgz?dl=https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+      "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+      "dev": true,
+      "requires": {
+        "glob": "~5.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/glob/-/glob-5.0.15.tgz?dl=https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "first-chunk-stream": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz?dl=https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+      "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
+      "dev": true
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/for-in/-/for-in-1.0.2.tgz?dl=https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/for-own/-/for-own-0.1.5.tgz?dl=https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.1"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/forever-agent/-/forever-agent-0.6.1.tgz?dl=https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.1.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/form-data/-/form-data-2.1.4.tgz?dl=https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fs-constants/-/fs-constants-1.0.0.tgz?dl=https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0=",
+      "dev": true
+    },
+    "fs-exists-sync": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz?dl=https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fs.realpath/-/fs.realpath-1.0.0.tgz?dl=https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fstream": {
+      "version": "1.0.11",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/fstream/-/fstream-1.0.11.tgz?dl=https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      }
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/gauge/-/gauge-2.7.4.tgz?dl=https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "gaze": {
+      "version": "1.1.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/gaze/-/gaze-1.1.3.tgz?dl=https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+      "integrity": "sha1-xEFzPhO5J6yMD/C0w7Az8ogSkko=",
+      "dev": true,
+      "requires": {
+        "globule": "^1.0.0"
+      }
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/generate-function/-/generate-function-2.0.0.tgz?dl=https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/generate-object-property/-/generate-object-property-1.2.0.tgz?dl=https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/get-caller-file/-/get-caller-file-1.0.2.tgz?dl=https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "dev": true
+    },
+    "get-proxy": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/get-proxy/-/get-proxy-1.1.0.tgz?dl=https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz",
+      "integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=",
+      "dev": true,
+      "requires": {
+        "rc": "^1.1.2"
+      }
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/get-stdin/-/get-stdin-4.0.1.tgz?dl=https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
+    "getobject": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/getobject/-/getobject-0.1.0.tgz?dl=https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+      "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/getpass/-/getpass-0.1.7.tgz?dl=https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/assert-plus/-/assert-plus-1.0.0.tgz?dl=https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "gifsicle": {
+      "version": "3.0.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/gifsicle/-/gifsicle-3.0.4.tgz?dl=https://registry.npmjs.org/gifsicle/-/gifsicle-3.0.4.tgz",
+      "integrity": "sha1-9Fy17RAWW2ZdySng6TKLbIId+js=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "bin-build": "^2.0.0",
+        "bin-wrapper": "^3.0.0",
+        "logalot": "^2.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.0.6",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/glob/-/glob-7.0.6.tgz?dl=https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+      "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/glob-base/-/glob-base-0.3.0.tgz?dl=https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "dev": true,
+      "requires": {
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/glob-parent/-/glob-parent-2.0.0.tgz?dl=https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^2.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-extglob/-/is-extglob-1.0.0.tgz?dl=https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-glob/-/is-glob-2.0.1.tgz?dl=https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
+      }
+    },
+    "glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/glob-parent/-/glob-parent-3.1.0.tgz?dl=https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      }
+    },
+    "glob-stream": {
+      "version": "5.3.5",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/glob-stream/-/glob-stream-5.3.5.tgz?dl=https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+      "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+      "dev": true,
+      "requires": {
+        "extend": "^3.0.0",
+        "glob": "^5.0.3",
+        "glob-parent": "^3.0.0",
+        "micromatch": "^2.3.7",
+        "ordered-read-streams": "^0.3.0",
+        "through2": "^0.6.0",
+        "to-absolute-glob": "^0.1.1",
+        "unique-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/glob/-/glob-5.0.15.tgz?dl=https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "global-modules": {
+      "version": "0.2.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/global-modules/-/global-modules-0.2.3.tgz?dl=https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+      "dev": true,
+      "requires": {
+        "global-prefix": "^0.1.4",
+        "is-windows": "^0.2.0"
+      }
+    },
+    "global-prefix": {
+      "version": "0.1.5",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/global-prefix/-/global-prefix-0.1.5.tgz?dl=https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+      "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.0",
+        "ini": "^1.3.4",
+        "is-windows": "^0.2.0",
+        "which": "^1.2.12"
+      }
+    },
+    "globule": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/globule/-/globule-1.2.0.tgz?dl=https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
+      "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+      "dev": true,
+      "requires": {
+        "glob": "~7.1.1",
+        "lodash": "~4.17.4",
+        "minimatch": "~3.0.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/glob/-/glob-7.1.2.tgz?dl=https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "glogg": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/glogg/-/glogg-1.0.1.tgz?dl=https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+      "integrity": "sha1-3PdY5EeJzD89MsHzVio2duajSBA=",
+      "dev": true,
+      "requires": {
+        "sparkles": "^1.0.0"
+      }
+    },
+    "got": {
+      "version": "5.7.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/got/-/got-5.7.1.tgz?dl=https://registry.npmjs.org/got/-/got-5.7.1.tgz",
+      "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
+      "dev": true,
+      "requires": {
+        "create-error-class": "^3.0.1",
+        "duplexer2": "^0.1.4",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "node-status-codes": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "parse-json": "^2.1.0",
+        "pinkie-promise": "^2.0.0",
+        "read-all-stream": "^3.0.0",
+        "readable-stream": "^2.0.5",
+        "timed-out": "^3.0.0",
+        "unzip-response": "^1.0.2",
+        "url-parse-lax": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/graceful-fs/-/graceful-fs-4.1.11.tgz?dl=https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/graceful-readlink/-/graceful-readlink-1.0.1.tgz?dl=https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "grunt": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/grunt/-/grunt-1.0.2.tgz?dl=https://registry.npmjs.org/grunt/-/grunt-1.0.2.tgz",
+      "integrity": "sha1-TmpeaVtwRy/VME9fqeNCNoNqc7w=",
+      "dev": true,
+      "requires": {
+        "coffeescript": "~1.10.0",
+        "dateformat": "~1.0.12",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.3.0",
+        "glob": "~7.0.0",
+        "grunt-cli": "~1.2.0",
+        "grunt-known-options": "~1.1.0",
+        "grunt-legacy-log": "~1.0.0",
+        "grunt-legacy-util": "~1.0.0",
+        "iconv-lite": "~0.4.13",
+        "js-yaml": "~3.5.2",
+        "minimatch": "~3.0.2",
+        "nopt": "~3.0.6",
+        "path-is-absolute": "~1.0.0",
+        "rimraf": "~2.2.8"
+      },
+      "dependencies": {
+        "grunt-cli": {
+          "version": "1.2.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/grunt-cli/-/grunt-cli-1.2.0.tgz?dl=https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
+          "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
+          "dev": true,
+          "requires": {
+            "findup-sync": "~0.3.0",
+            "grunt-known-options": "~1.1.0",
+            "nopt": "~3.0.6",
+            "resolve": "~1.1.0"
+          }
+        }
+      }
+    },
+    "grunt-autoprefixer": {
+      "version": "3.0.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/grunt-autoprefixer/-/grunt-autoprefixer-3.0.4.tgz?dl=https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-3.0.4.tgz",
+      "integrity": "sha1-/kLiR7z6ucKSoSwGLa1PNb3pAsU=",
+      "dev": true,
+      "requires": {
+        "autoprefixer-core": "^5.1.7",
+        "chalk": "~1.0.0",
+        "diff": "~1.3.0",
+        "postcss": "^4.1.11"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "1.1.1",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ansi-regex/-/ansi-regex-1.1.1.tgz?dl=https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+          "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/chalk/-/chalk-1.0.0.tgz?dl=https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "integrity": "sha1-s89O0P9Tl8mcdbj2edsvUoMfltw=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.0.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^1.0.3",
+            "strip-ansi": "^2.0.1",
+            "supports-color": "^1.3.0"
+          }
+        },
+        "has-ansi": {
+          "version": "1.0.3",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/has-ansi/-/has-ansi-1.0.3.tgz?dl=https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+          "integrity": "sha1-wLWxYV2eOCsP9nFp2We0JeSMpTg=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^1.1.0",
+            "get-stdin": "^4.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/strip-ansi/-/strip-ansi-2.0.1.tgz?dl=https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+          "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^1.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "1.3.1",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/supports-color/-/supports-color-1.3.1.tgz?dl=https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
+          "integrity": "sha1-FXWN8J2P87SswwdTn6vicJXhBC0=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-contrib-clean": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/grunt-contrib-clean/-/grunt-contrib-clean-1.1.0.tgz?dl=https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-1.1.0.tgz",
+      "integrity": "sha1-Vkq/LQN4qYOhW54/MO51tzjEBjg=",
+      "dev": true,
+      "requires": {
+        "async": "^1.5.2",
+        "rimraf": "^2.5.1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.2",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/rimraf/-/rimraf-2.6.2.tgz?dl=https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        }
+      }
+    },
+    "grunt-contrib-copy": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz?dl=https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
+      "integrity": "sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "file-sync-cmp": "^0.1.0"
+      }
+    },
+    "grunt-contrib-imagemin": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/grunt-contrib-imagemin/-/grunt-contrib-imagemin-1.0.1.tgz?dl=https://registry.npmjs.org/grunt-contrib-imagemin/-/grunt-contrib-imagemin-1.0.1.tgz",
+      "integrity": "sha1-5Ho1YTN29MqpwfkERlA8rhyUTXk=",
+      "dev": true,
+      "requires": {
+        "async": "^1.5.2",
+        "chalk": "^1.0.0",
+        "gulp-rename": "^1.2.0",
+        "imagemin": "^4.0.0",
+        "pretty-bytes": "^3.0.1"
+      }
+    },
+    "grunt-contrib-jshint": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/grunt-contrib-jshint/-/grunt-contrib-jshint-1.1.0.tgz?dl=https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-1.1.0.tgz",
+      "integrity": "sha1-Np2QmyWTxA6L55lAshNAhQx5Oaw=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "hooker": "^0.2.3",
+        "jshint": "~2.9.4"
+      }
+    },
+    "grunt-contrib-watch": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/grunt-contrib-watch/-/grunt-contrib-watch-1.1.0.tgz?dl=https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-1.1.0.tgz",
+      "integrity": "sha1-wUPKW4JLKIoCS4VmOaU0Wu23jtQ=",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.0",
+        "gaze": "^1.1.0",
+        "lodash": "^4.17.10",
+        "tiny-lr": "^1.1.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/async/-/async-2.6.1.tgz?dl=https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        }
+      }
+    },
+    "grunt-cssjanus": {
+      "version": "0.4.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/grunt-cssjanus/-/grunt-cssjanus-0.4.0.tgz?dl=https://registry.npmjs.org/grunt-cssjanus/-/grunt-cssjanus-0.4.0.tgz",
+      "integrity": "sha1-j8rmiZDMU+wpReVi3j3Jn17MMXs=",
+      "dev": true,
+      "requires": {
+        "cssjanus": "^1.1.2"
+      }
+    },
+    "grunt-dev-update": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/grunt-dev-update/-/grunt-dev-update-2.3.0.tgz?dl=https://registry.npmjs.org/grunt-dev-update/-/grunt-dev-update-2.3.0.tgz",
+      "integrity": "sha1-DVDkhjrEBB1rufuW1ka4rSUJYBg=",
+      "dev": true,
+      "requires": {
+        "async-each-series": "^1.1.0",
+        "findup-sync": "^0.4.0",
+        "inquirer": "^0.12.0",
+        "lodash": "^4.8.2",
+        "npm-package-arg": "^4.1.0",
+        "semver": "^5.1.0"
+      },
+      "dependencies": {
+        "findup-sync": {
+          "version": "0.4.3",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/findup-sync/-/findup-sync-0.4.3.tgz?dl=https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+          "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
+          "dev": true,
+          "requires": {
+            "detect-file": "^0.1.0",
+            "is-glob": "^2.0.1",
+            "micromatch": "^2.3.7",
+            "resolve-dir": "^0.1.0"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-extglob/-/is-extglob-1.0.0.tgz?dl=https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-glob/-/is-glob-2.0.1.tgz?dl=https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
+      }
+    },
+    "grunt-known-options": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/grunt-known-options/-/grunt-known-options-1.1.0.tgz?dl=https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz",
+      "integrity": "sha1-pCdO6zL6dl2lp6OxcSYXzjsUQUk=",
+      "dev": true
+    },
+    "grunt-legacy-log": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/grunt-legacy-log/-/grunt-legacy-log-1.0.2.tgz?dl=https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.2.tgz",
+      "integrity": "sha1-fXRAQmrOd7IG50+ZPjMuKhWjkE4=",
+      "dev": true,
+      "requires": {
+        "colors": "~1.1.2",
+        "grunt-legacy-log-utils": "~1.0.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.17.5"
+      }
+    },
+    "grunt-legacy-log-utils": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz?dl=https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz",
+      "integrity": "sha1-p7ji0Ps1taUPSvmG/BEnSevJbz0=",
+      "dev": true,
+      "requires": {
+        "chalk": "~1.1.1",
+        "lodash": "~4.3.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash/-/lodash-4.3.0.tgz?dl=https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
+          "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-util": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/grunt-legacy-util/-/grunt-legacy-util-1.0.0.tgz?dl=https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.0.0.tgz",
+      "integrity": "sha1-OGqnjcbtUJhsKxiVcmWxtIq7m4Y=",
+      "dev": true,
+      "requires": {
+        "async": "~1.5.2",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.3.0",
+        "underscore.string": "~3.2.3",
+        "which": "~1.2.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash/-/lodash-4.3.0.tgz?dl=https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
+          "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-sass": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/grunt-sass/-/grunt-sass-2.1.0.tgz?dl=https://registry.npmjs.org/grunt-sass/-/grunt-sass-2.1.0.tgz",
+      "integrity": "sha1-t7odhe9MLZt9gZX+ZfZkrHVU76E=",
+      "dev": true,
+      "requires": {
+        "each-async": "^1.0.0",
+        "node-sass": "^4.7.2",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "grunt-text-replace": {
+      "version": "0.4.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/grunt-text-replace/-/grunt-text-replace-0.4.0.tgz?dl=https://registry.npmjs.org/grunt-text-replace/-/grunt-text-replace-0.4.0.tgz",
+      "integrity": "sha1-252c5Z4v5J2id+nbwZXD4Rz7FsI=",
+      "dev": true
+    },
+    "grunt-wp-readme-to-markdown": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/grunt-wp-readme-to-markdown/-/grunt-wp-readme-to-markdown-2.0.1.tgz?dl=https://registry.npmjs.org/grunt-wp-readme-to-markdown/-/grunt-wp-readme-to-markdown-2.0.1.tgz",
+      "integrity": "sha1-QGzV6YmIWA3B0W6AXE4uYJJWhVI=",
+      "dev": true
+    },
+    "gulp-decompress": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/gulp-decompress/-/gulp-decompress-1.2.0.tgz?dl=https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz",
+      "integrity": "sha1-jutlpeAV+O2FMsr+KEVJYGJvDcc=",
+      "dev": true,
+      "requires": {
+        "archive-type": "^3.0.0",
+        "decompress": "^3.0.0",
+        "gulp-util": "^3.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "gulp-rename": {
+      "version": "1.2.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/gulp-rename/-/gulp-rename-1.2.3.tgz?dl=https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.3.tgz",
+      "integrity": "sha1-N7dSmOnT5sD+msTqwTzjvlQ0ZGs=",
+      "dev": true
+    },
+    "gulp-sourcemaps": {
+      "version": "1.6.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz?dl=https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+      "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+      "dev": true,
+      "requires": {
+        "convert-source-map": "^1.1.1",
+        "graceful-fs": "^4.1.2",
+        "strip-bom": "^2.0.0",
+        "through2": "^2.0.0",
+        "vinyl": "^1.0.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.3",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/through2/-/through2-2.0.3.tgz?dl=https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
+          }
+        }
+      }
+    },
+    "gulp-util": {
+      "version": "3.0.8",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/gulp-util/-/gulp-util-3.0.8.tgz?dl=https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+      "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+      "dev": true,
+      "requires": {
+        "array-differ": "^1.0.0",
+        "array-uniq": "^1.0.2",
+        "beeper": "^1.0.0",
+        "chalk": "^1.0.0",
+        "dateformat": "^2.0.0",
+        "fancy-log": "^1.1.0",
+        "gulplog": "^1.0.0",
+        "has-gulplog": "^0.1.0",
+        "lodash._reescape": "^3.0.0",
+        "lodash._reevaluate": "^3.0.0",
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.template": "^3.0.0",
+        "minimist": "^1.1.0",
+        "multipipe": "^0.1.2",
+        "object-assign": "^3.0.0",
+        "replace-ext": "0.0.1",
+        "through2": "^2.0.0",
+        "vinyl": "^0.5.0"
+      },
+      "dependencies": {
+        "dateformat": {
+          "version": "2.2.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/dateformat/-/dateformat-2.2.0.tgz?dl=https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+          "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/object-assign/-/object-assign-3.0.0.tgz?dl=https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+          "dev": true
+        },
+        "through2": {
+          "version": "2.0.3",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/through2/-/through2-2.0.3.tgz?dl=https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
+          }
+        },
+        "vinyl": {
+          "version": "0.5.3",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/vinyl/-/vinyl-0.5.3.tgz?dl=https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+          "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+          "dev": true,
+          "requires": {
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
+            "replace-ext": "0.0.1"
+          }
+        }
+      }
+    },
+    "gulplog": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/gulplog/-/gulplog-1.0.0.tgz?dl=https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+      "dev": true,
+      "requires": {
+        "glogg": "^1.0.0"
+      }
+    },
+    "har-validator": {
+      "version": "2.0.6",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/har-validator/-/har-validator-2.0.6.tgz?dl=https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "commander": "^2.9.0",
+        "is-my-json-valid": "^2.12.4",
+        "pinkie-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/commander/-/commander-2.15.1.tgz?dl=https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha1-30boZ9D8Kuxmo0ZitAapzK//Ww8=",
+          "dev": true
+        }
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/has-ansi/-/has-ansi-2.0.0.tgz?dl=https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-gulplog": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/has-gulplog/-/has-gulplog-0.1.0.tgz?dl=https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+      "dev": true,
+      "requires": {
+        "sparkles": "^1.0.0"
+      }
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/has-unicode/-/has-unicode-2.0.1.tgz?dl=https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/hawk/-/hawk-3.1.3.tgz?dl=https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "dev": true,
+      "requires": {
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
+      }
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/hoek/-/hoek-2.16.3.tgz?dl=https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "dev": true
+    },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz?dl=https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "^1.0.0"
+      }
+    },
+    "hooker": {
+      "version": "0.2.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/hooker/-/hooker-0.2.3.tgz?dl=https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.6.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/hosted-git-info/-/hosted-git-info-2.6.0.tgz?dl=https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+      "integrity": "sha1-IyNbKasjDFdqqw1PE/wEawsDgiI=",
+      "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.8.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/htmlparser2/-/htmlparser2-3.8.3.tgz?dl=https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/isarray/-/isarray-0.0.1.tgz?dl=https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/readable-stream/-/readable-stream-1.1.14.tgz?dl=https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string_decoder/-/string_decoder-0.10.31.tgz?dl=https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "http-parser-js": {
+      "version": "0.4.13",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/http-parser-js/-/http-parser-js-0.4.13.tgz?dl=https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
+      "integrity": "sha1-O9bW/ebjFyyTNMOzO2wZPYD+ETc=",
+      "dev": true
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/http-signature/-/http-signature-1.1.1.tgz?dl=https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^0.2.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.23",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/iconv-lite/-/iconv-lite-0.4.23.tgz?dl=https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha1-KXhx9jvlB63Pv8pxXQzQ7thOmmM=",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "imagemin": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/imagemin/-/imagemin-4.0.0.tgz?dl=https://registry.npmjs.org/imagemin/-/imagemin-4.0.0.tgz",
+      "integrity": "sha1-6Q5/CTaDZZXxj6Ff6Qb0+iWeqEc=",
+      "dev": true,
+      "requires": {
+        "buffer-to-vinyl": "^1.0.0",
+        "concat-stream": "^1.4.6",
+        "imagemin-gifsicle": "^4.0.0",
+        "imagemin-jpegtran": "^4.0.0",
+        "imagemin-optipng": "^4.0.0",
+        "imagemin-svgo": "^4.0.0",
+        "optional": "^0.1.0",
+        "readable-stream": "^2.0.0",
+        "stream-combiner2": "^1.1.1",
+        "vinyl-fs": "^2.1.1"
+      }
+    },
+    "imagemin-gifsicle": {
+      "version": "4.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/imagemin-gifsicle/-/imagemin-gifsicle-4.2.0.tgz?dl=https://registry.npmjs.org/imagemin-gifsicle/-/imagemin-gifsicle-4.2.0.tgz",
+      "integrity": "sha1-D++butNHbmt2iFc2zFsLh6CHV8o=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "gifsicle": "^3.0.0",
+        "is-gif": "^1.0.0",
+        "through2": "^0.6.1"
+      }
+    },
+    "imagemin-jpegtran": {
+      "version": "4.3.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/imagemin-jpegtran/-/imagemin-jpegtran-4.3.2.tgz?dl=https://registry.npmjs.org/imagemin-jpegtran/-/imagemin-jpegtran-4.3.2.tgz",
+      "integrity": "sha1-G8bR4r0T/bZNJFUm1jWn5d/rEvw=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "is-jpg": "^1.0.0",
+        "jpegtran-bin": "^3.0.0",
+        "through2": "^2.0.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.3",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/through2/-/through2-2.0.3.tgz?dl=https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
+          }
+        }
+      }
+    },
+    "imagemin-optipng": {
+      "version": "4.3.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/imagemin-optipng/-/imagemin-optipng-4.3.0.tgz?dl=https://registry.npmjs.org/imagemin-optipng/-/imagemin-optipng-4.3.0.tgz",
+      "integrity": "sha1-dgRmOrLuMVczJ0cm/Rw3TStErbY=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "exec-buffer": "^2.0.0",
+        "is-png": "^1.0.0",
+        "optipng-bin": "^3.0.0",
+        "through2": "^0.6.1"
+      }
+    },
+    "imagemin-svgo": {
+      "version": "4.2.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/imagemin-svgo/-/imagemin-svgo-4.2.1.tgz?dl=https://registry.npmjs.org/imagemin-svgo/-/imagemin-svgo-4.2.1.tgz",
+      "integrity": "sha1-VPB9xW9HJgRi32phxUvvtEtXvlU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "is-svg": "^1.0.0",
+        "svgo": "^0.6.0",
+        "through2": "^2.0.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.3",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/through2/-/through2-2.0.3.tgz?dl=https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
+          }
+        }
+      }
+    },
+    "in-publish": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/in-publish/-/in-publish-2.0.0.tgz?dl=https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/indent-string/-/indent-string-2.1.0.tgz?dl=https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/inflight/-/inflight-1.0.6.tgz?dl=https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/inherits/-/inherits-2.0.3.tgz?dl=https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ini/-/ini-1.3.5.tgz?dl=https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "0.12.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/inquirer/-/inquirer-0.12.0.tgz?dl=https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
+      }
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/invert-kv/-/invert-kv-1.0.0.tgz?dl=https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
+    },
+    "ip-regex": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ip-regex/-/ip-regex-1.0.3.tgz?dl=https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz",
+      "integrity": "sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0=",
+      "dev": true,
+      "optional": true
+    },
+    "is-absolute": {
+      "version": "0.1.7",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-absolute/-/is-absolute-0.1.7.tgz?dl=https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+      "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
+      "dev": true,
+      "requires": {
+        "is-relative": "^0.1.0"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-arrayish/-/is-arrayish-0.2.1.tgz?dl=https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-buffer/-/is-buffer-1.1.6.tgz?dl=https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+      "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-builtin-module/-/is-builtin-module-1.0.0.tgz?dl=https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^1.0.0"
+      }
+    },
+    "is-bzip2": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-bzip2/-/is-bzip2-1.0.0.tgz?dl=https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz",
+      "integrity": "sha1-XuWOqlounIDiFAe+3yOuWsCRs/w=",
+      "dev": true
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-dotfile/-/is-dotfile-1.0.3.tgz?dl=https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "dev": true
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz?dl=https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "dev": true,
+      "requires": {
+        "is-primitive": "^2.0.0"
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-extendable/-/is-extendable-0.1.1.tgz?dl=https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-extglob/-/is-extglob-2.1.1.tgz?dl=https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-finite/-/is-finite-1.0.2.tgz?dl=https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz?dl=https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-gif": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-gif/-/is-gif-1.0.0.tgz?dl=https://registry.npmjs.org/is-gif/-/is-gif-1.0.0.tgz",
+      "integrity": "sha1-ptKumIkwB7/6l6HYwB1jIFgyCX4=",
+      "dev": true,
+      "optional": true
+    },
+    "is-glob": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-glob/-/is-glob-3.1.0.tgz?dl=https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.0"
+      }
+    },
+    "is-gzip": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-gzip/-/is-gzip-1.0.0.tgz?dl=https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
+      "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM=",
+      "dev": true
+    },
+    "is-jpg": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-jpg/-/is-jpg-1.0.1.tgz?dl=https://registry.npmjs.org/is-jpg/-/is-jpg-1.0.1.tgz",
+      "integrity": "sha1-KW1X/dmc4BBDSnKD40armhA16XU=",
+      "dev": true,
+      "optional": true
+    },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz?dl=https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha1-ezUbjo7dTTmV1NBmaA5mTZRpaCQ=",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "2.17.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz?dl=https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+      "integrity": "sha1-ayEDoojpTvPeXPFdKd2F/Et41lw=",
+      "dev": true,
+      "requires": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "is-natural-number": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-natural-number/-/is-natural-number-2.1.1.tgz?dl=https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz",
+      "integrity": "sha1-fUxXKDd+84bD4ZSpkRv1fG3DNec=",
+      "dev": true
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-number/-/is-number-2.1.0.tgz?dl=https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-obj/-/is-obj-1.0.1.tgz?dl=https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-png": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-png/-/is-png-1.1.0.tgz?dl=https://registry.npmjs.org/is-png/-/is-png-1.1.0.tgz",
+      "integrity": "sha1-1XSxK/J1wDUEVVcLDltXqwYgd84=",
+      "dev": true,
+      "optional": true
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz?dl=https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "dev": true
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-primitive/-/is-primitive-2.0.0.tgz?dl=https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-property/-/is-property-1.0.2.tgz?dl=https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-redirect/-/is-redirect-1.0.0.tgz?dl=https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
+    "is-relative": {
+      "version": "0.1.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-relative/-/is-relative-0.1.3.tgz?dl=https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+      "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=",
+      "dev": true
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz?dl=https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-stream/-/is-stream-1.1.0.tgz?dl=https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-svg": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-svg/-/is-svg-1.1.1.tgz?dl=https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz",
+      "integrity": "sha1-rA76r7ZTrFhHNwix+HNjbKEQ4xs=",
+      "dev": true,
+      "optional": true
+    },
+    "is-tar": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-tar/-/is-tar-1.0.0.tgz?dl=https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz",
+      "integrity": "sha1-L2suF5LB9bs2UZrKqdZcDSb+hT0=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-typedarray/-/is-typedarray-1.0.0.tgz?dl=https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-url": {
+      "version": "1.2.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-url/-/is-url-1.2.4.tgz?dl=https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha1-BKTfRtKMTP89c9Af8Gq+sxihqlI=",
+      "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-utf8/-/is-utf8-0.2.1.tgz?dl=https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-valid-glob": {
+      "version": "0.3.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-valid-glob/-/is-valid-glob-0.3.0.tgz?dl=https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+      "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-windows/-/is-windows-0.2.0.tgz?dl=https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+      "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+      "dev": true
+    },
+    "is-zip": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-zip/-/is-zip-1.0.0.tgz?dl=https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz",
+      "integrity": "sha1-R7Co/004p2QxzP2ZqOFaTIa6IyU=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/isarray/-/isarray-1.0.0.tgz?dl=https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/isexe/-/isexe-2.0.0.tgz?dl=https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/isobject/-/isobject-2.1.0.tgz?dl=https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
+      "requires": {
+        "isarray": "1.0.0"
+      }
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/isstream/-/isstream-0.1.2.tgz?dl=https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "jpegtran-bin": {
+      "version": "3.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jpegtran-bin/-/jpegtran-bin-3.2.0.tgz?dl=https://registry.npmjs.org/jpegtran-bin/-/jpegtran-bin-3.2.0.tgz",
+      "integrity": "sha1-9g7PSumZwL2tLp+83ytvCYHnops=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "bin-build": "^2.0.0",
+        "bin-wrapper": "^3.0.0",
+        "logalot": "^2.0.0"
+      }
+    },
+    "js-base64": {
+      "version": "2.1.9",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/js-base64/-/js-base64-2.1.9.tgz?dl=https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+      "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.5.5",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/js-yaml/-/js-yaml-3.5.5.tgz?dl=https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
+      "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.2",
+        "esprima": "^2.6.0"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsbn/-/jsbn-0.1.1.tgz?dl=https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "optional": true
+    },
+    "jshint": {
+      "version": "2.9.5",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jshint/-/jshint-2.9.5.tgz?dl=https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
+      "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
+      "dev": true,
+      "requires": {
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "3.7.x",
+        "minimatch": "~3.0.2",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.7.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash/-/lodash-3.7.0.tgz?dl=https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+          "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/strip-json-comments/-/strip-json-comments-1.0.4.tgz?dl=https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+          "dev": true
+        }
+      }
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/json-schema/-/json-schema-0.2.3.tgz?dl=https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz?dl=https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz?dl=https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsonify/-/jsonify-0.0.0.tgz?dl=https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsonpointer/-/jsonpointer-4.0.1.tgz?dl=https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jsprim/-/jsprim-1.4.1.tgz?dl=https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/assert-plus/-/assert-plus-1.0.0.tgz?dl=https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/kind-of/-/kind-of-3.2.2.tgz?dl=https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
+    },
+    "lazy-req": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lazy-req/-/lazy-req-1.1.0.tgz?dl=https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
+      "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w=",
+      "dev": true,
+      "optional": true
+    },
+    "lazystream": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lazystream/-/lazystream-1.0.0.tgz?dl=https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.5"
+      }
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lcid/-/lcid-1.0.0.tgz?dl=https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
+    },
+    "livereload-js": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/livereload-js/-/livereload-js-2.3.0.tgz?dl=https://registry.npmjs.org/livereload-js/-/livereload-js-2.3.0.tgz",
+      "integrity": "sha1-w6si6Kr1vzUF2A0JjLrWdyZUjJo=",
+      "dev": true
+    },
+    "load-grunt-tasks": {
+      "version": "3.5.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/load-grunt-tasks/-/load-grunt-tasks-3.5.2.tgz?dl=https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.5.2.tgz",
+      "integrity": "sha1-ByhWEYD9IP+KaSdQWFL8WKrqDIg=",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.0",
+        "multimatch": "^2.0.0",
+        "pkg-up": "^1.0.0",
+        "resolve-pkg": "^0.1.0"
+      }
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/load-json-file/-/load-json-file-1.1.0.tgz?dl=https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash/-/lodash-4.17.10.tgz?dl=https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc=",
+      "dev": true
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz?dl=https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basetostring": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz?dl=https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+      "dev": true
+    },
+    "lodash._basevalues": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz?dl=https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash._getnative/-/lodash._getnative-3.9.1.tgz?dl=https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz?dl=https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash._reescape": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash._reescape/-/lodash._reescape-3.0.0.tgz?dl=https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+      "dev": true
+    },
+    "lodash._reevaluate": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz?dl=https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+      "dev": true
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz?dl=https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
+    "lodash._root": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash._root/-/lodash._root-3.0.1.tgz?dl=https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+      "dev": true
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.assign/-/lodash.assign-4.2.0.tgz?dl=https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz?dl=https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
+    "lodash.escape": {
+      "version": "3.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.escape/-/lodash.escape-3.2.0.tgz?dl=https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+      "dev": true,
+      "requires": {
+        "lodash._root": "^3.0.0"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz?dl=https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.isarray/-/lodash.isarray-3.0.4.tgz?dl=https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.isequal/-/lodash.isequal-4.5.0.tgz?dl=https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.keys/-/lodash.keys-3.1.2.tgz?dl=https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "lodash.mergewith": {
+      "version": "4.6.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz?dl=https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+      "integrity": "sha1-Y5BX5ybDr72z59QnQcqo1uQzWSc=",
+      "dev": true
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.restparam/-/lodash.restparam-3.6.1.tgz?dl=https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+      "dev": true
+    },
+    "lodash.template": {
+      "version": "3.6.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.template/-/lodash.template-3.6.2.tgz?dl=https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash._basetostring": "^3.0.0",
+        "lodash._basevalues": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0",
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.escape": "^3.0.0",
+        "lodash.keys": "^3.0.0",
+        "lodash.restparam": "^3.0.0",
+        "lodash.templatesettings": "^3.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "3.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz?dl=https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+      "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.escape": "^3.0.0"
+      }
+    },
+    "logalot": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/logalot/-/logalot-2.1.0.tgz?dl=https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz",
+      "integrity": "sha1-X46MkNME7fElMJUaVVSruMXj9VI=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "figures": "^1.3.5",
+        "squeak": "^1.0.0"
+      }
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/longest/-/longest-1.0.1.tgz?dl=https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true,
+      "optional": true
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/loud-rejection/-/loud-rejection-1.6.0.tgz?dl=https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lowercase-keys/-/lowercase-keys-1.0.1.tgz?dl=https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
+      "dev": true
+    },
+    "lpad-align": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lpad-align/-/lpad-align-1.1.2.tgz?dl=https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.2.tgz",
+      "integrity": "sha1-IfYArBwwlcPG5JfuZyce4ISB/p4=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "get-stdin": "^4.0.1",
+        "indent-string": "^2.1.0",
+        "longest": "^1.0.0",
+        "meow": "^3.3.0"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/lru-cache/-/lru-cache-4.1.3.tgz?dl=https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/map-obj/-/map-obj-1.0.1.tgz?dl=https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
+    "matchdep": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/matchdep/-/matchdep-1.0.1.tgz?dl=https://registry.npmjs.org/matchdep/-/matchdep-1.0.1.tgz",
+      "integrity": "sha1-pXozgESR+64girqPaDgEN6vC3KU=",
+      "dev": true,
+      "requires": {
+        "findup-sync": "~0.3.0",
+        "micromatch": "^2.3.7",
+        "resolve": "~1.1.6",
+        "stack-trace": "0.0.9"
+      }
+    },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/math-random/-/math-random-1.0.1.tgz?dl=https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+      "dev": true
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/meow/-/meow-3.7.0.tgz?dl=https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
+      }
+    },
+    "merge-stream": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/merge-stream/-/merge-stream-1.0.1.tgz?dl=https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+      "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/micromatch/-/micromatch-2.3.11.tgz?dl=https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-extglob/-/is-extglob-1.0.0.tgz?dl=https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-glob/-/is-glob-2.0.1.tgz?dl=https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
+      }
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/mime-db/-/mime-db-1.33.0.tgz?dl=https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha1-o0kgUKXLm2NFBUHjnZeI0icng9s=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/mime-types/-/mime-types-2.1.18.tgz?dl=https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha1-bzI/YKg9ERRvgx/xH9ZuL+VQO7g=",
+      "dev": true,
+      "requires": {
+        "mime-db": "~1.33.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/minimatch/-/minimatch-3.0.4.tgz?dl=https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/minimist/-/minimist-1.2.0.tgz?dl=https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/mkdirp/-/mkdirp-0.5.1.tgz?dl=https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/minimist/-/minimist-0.0.8.tgz?dl=https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ms/-/ms-2.0.0.tgz?dl=https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "multimatch": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/multimatch/-/multimatch-2.1.0.tgz?dl=https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+      "dev": true,
+      "requires": {
+        "array-differ": "^1.0.0",
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "minimatch": "^3.0.0"
+      }
+    },
+    "multipipe": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/multipipe/-/multipipe-0.1.2.tgz?dl=https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+      "dev": true,
+      "requires": {
+        "duplexer2": "0.0.2"
+      },
+      "dependencies": {
+        "duplexer2": {
+          "version": "0.0.2",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/duplexer2/-/duplexer2-0.0.2.tgz?dl=https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+          "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~1.1.9"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/isarray/-/isarray-0.0.1.tgz?dl=https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/readable-stream/-/readable-stream-1.1.14.tgz?dl=https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string_decoder/-/string_decoder-0.10.31.tgz?dl=https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "mute-stream": {
+      "version": "0.0.5",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/mute-stream/-/mute-stream-0.0.5.tgz?dl=https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/nan/-/nan-2.10.0.tgz?dl=https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha1-ltDNYQ69WNS03pzAxoKM2pnHVI8=",
+      "dev": true
+    },
+    "node-gyp": {
+      "version": "3.6.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/node-gyp/-/node-gyp-3.6.2.tgz?dl=https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+      "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
+      "dev": true,
+      "requires": {
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "2",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/semver/-/semver-5.3.0.tgz?dl=https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true
+        }
+      }
+    },
+    "node-sass": {
+      "version": "4.9.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/node-sass/-/node-sass-4.9.0.tgz?dl=https://registry.npmjs.org/node-sass/-/node-sass-4.9.0.tgz",
+      "integrity": "sha1-0biqhV2Y7WhNaEjbkpogdxzCrlI=",
+      "dev": true,
+      "requires": {
+        "async-foreach": "^0.1.3",
+        "chalk": "^1.1.1",
+        "cross-spawn": "^3.0.0",
+        "gaze": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "glob": "^7.0.3",
+        "in-publish": "^2.0.0",
+        "lodash.assign": "^4.2.0",
+        "lodash.clonedeep": "^4.3.2",
+        "lodash.mergewith": "^4.6.0",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.10.0",
+        "node-gyp": "^3.3.1",
+        "npmlog": "^4.0.0",
+        "request": "~2.79.0",
+        "sass-graph": "^2.2.4",
+        "stdout-stream": "^1.4.0",
+        "true-case-path": "^1.0.2"
+      }
+    },
+    "node-status-codes": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/node-status-codes/-/node-status-codes-1.0.0.tgz?dl=https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
+      "dev": true
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/nopt/-/nopt-3.0.6.tgz?dl=https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/normalize-package-data/-/normalize-package-data-2.4.0.tgz?dl=https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/normalize-path/-/normalize-path-2.1.1.tgz?dl=https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
+      }
+    },
+    "npm-package-arg": {
+      "version": "4.2.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/npm-package-arg/-/npm-package-arg-4.2.1.tgz?dl=https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.2.1.tgz",
+      "integrity": "sha1-WTMD/eqF98Qid18X+et2cPaA4+w=",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.5",
+        "semver": "^5.1.0"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/npmlog/-/npmlog-4.1.2.tgz?dl=https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "num2fraction": {
+      "version": "1.2.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/num2fraction/-/num2fraction-1.2.2.tgz?dl=https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+      "dev": true
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/number-is-nan/-/number-is-nan-1.0.1.tgz?dl=https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/oauth-sign/-/oauth-sign-0.8.2.tgz?dl=https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/object-assign/-/object-assign-4.1.1.tgz?dl=https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/object.omit/-/object.omit-2.0.1.tgz?dl=https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "dev": true,
+      "requires": {
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/once/-/once-1.4.0.tgz?dl=https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/onetime/-/onetime-1.1.0.tgz?dl=http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
+    "optional": {
+      "version": "0.1.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/optional/-/optional-0.1.4.tgz?dl=https://registry.npmjs.org/optional/-/optional-0.1.4.tgz",
+      "integrity": "sha1-zbGpvtxzfSAl9pDO61DgSURP1bM=",
+      "dev": true
+    },
+    "optipng-bin": {
+      "version": "3.1.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/optipng-bin/-/optipng-bin-3.1.4.tgz?dl=https://registry.npmjs.org/optipng-bin/-/optipng-bin-3.1.4.tgz",
+      "integrity": "sha1-ldNPLEiHBPb9cGBr/qDGWfHZXYQ=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "bin-build": "^2.0.0",
+        "bin-wrapper": "^3.0.0",
+        "logalot": "^2.0.0"
+      }
+    },
+    "ordered-read-streams": {
+      "version": "0.3.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz?dl=https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+      "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+      "dev": true,
+      "requires": {
+        "is-stream": "^1.0.1",
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "os-filter-obj": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/os-filter-obj/-/os-filter-obj-1.0.3.tgz?dl=https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz",
+      "integrity": "sha1-WRUzDZDs7VV9LZOKMcbdIU2cY60=",
+      "dev": true,
+      "optional": true
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/os-homedir/-/os-homedir-1.0.2.tgz?dl=https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/os-locale/-/os-locale-1.4.0.tgz?dl=https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
+      "requires": {
+        "lcid": "^1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/os-tmpdir/-/os-tmpdir-1.0.2.tgz?dl=https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/osenv/-/osenv-0.1.5.tgz?dl=https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/parse-glob/-/parse-glob-3.0.4.tgz?dl=https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "dev": true,
+      "requires": {
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-extglob/-/is-extglob-1.0.0.tgz?dl=https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-glob/-/is-glob-2.0.1.tgz?dl=https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/parse-json/-/parse-json-2.2.0.tgz?dl=https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/parse-passwd/-/parse-passwd-1.0.0.tgz?dl=https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/path-dirname/-/path-dirname-1.0.2.tgz?dl=https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/path-exists/-/path-exists-2.1.0.tgz?dl=https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/path-is-absolute/-/path-is-absolute-1.0.1.tgz?dl=https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/path-type/-/path-type-1.1.0.tgz?dl=https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pend/-/pend-1.2.0.tgz?dl=https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pify/-/pify-2.3.0.tgz?dl=https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pinkie/-/pinkie-2.0.4.tgz?dl=https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pinkie-promise/-/pinkie-promise-2.0.1.tgz?dl=https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "pkg-up": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pkg-up/-/pkg-up-1.0.0.tgz?dl=https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
+      "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0"
+      }
+    },
+    "postcss": {
+      "version": "4.1.16",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/postcss/-/postcss-4.1.16.tgz?dl=https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
+      "integrity": "sha1-TESbTIr53zyvbTf44eV10DYXWNw=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "~2.3.0",
+        "js-base64": "~2.1.8",
+        "source-map": "~0.4.2"
+      }
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/prepend-http/-/prepend-http-1.0.4.tgz?dl=https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/preserve/-/preserve-0.2.0.tgz?dl=https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
+    },
+    "pretty-bytes": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pretty-bytes/-/pretty-bytes-3.0.1.tgz?dl=https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
+      "integrity": "sha1-J9AAjXeAY6C0gRuzXHnxvV1fvM8=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/process-nextick-args/-/process-nextick-args-2.0.0.tgz?dl=https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/pseudomap/-/pseudomap-1.0.2.tgz?dl=https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/punycode/-/punycode-1.4.1.tgz?dl=https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/q/-/q-1.5.1.tgz?dl=https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true,
+      "optional": true
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/qs/-/qs-6.5.2.tgz?dl=https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
+      "dev": true
+    },
+    "randomatic": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/randomatic/-/randomatic-3.0.0.tgz?dl=https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+      "integrity": "sha1-01SQAw6091eN4pLObfsEqRoSiSM=",
+      "dev": true,
+      "requires": {
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/is-number/-/is-number-4.0.0.tgz?dl=https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/kind-of/-/kind-of-6.0.2.tgz?dl=https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+          "dev": true
+        }
+      }
+    },
+    "raw-body": {
+      "version": "1.1.7",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/raw-body/-/raw-body-1.1.7.tgz?dl=https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
+      "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
+      "dev": true,
+      "requires": {
+        "bytes": "1",
+        "string_decoder": "0.10"
+      },
+      "dependencies": {
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string_decoder/-/string_decoder-0.10.31.tgz?dl=https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "rc": {
+      "version": "1.2.7",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/rc/-/rc-1.2.7.tgz?dl=https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+      "integrity": "sha1-ihDKMNWI0ARkNgNyuJDQbazQIpc=",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.5.1",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      }
+    },
+    "read-all-stream": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/read-all-stream/-/read-all-stream-3.1.0.tgz?dl=https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "^2.0.0",
+        "readable-stream": "^2.0.0"
+      }
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/read-pkg/-/read-pkg-1.1.0.tgz?dl=https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/read-pkg-up/-/read-pkg-up-1.0.1.tgz?dl=https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/readable-stream/-/readable-stream-2.3.6.tgz?dl=https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "readline2": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/readline2/-/readline2-1.0.1.tgz?dl=https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "mute-stream": "0.0.5"
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/redent/-/redent-1.0.0.tgz?dl=https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      }
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/regex-cache/-/regex-cache-0.4.4.tgz?dl=https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "^0.1.3"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz?dl=https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/repeat-element/-/repeat-element-1.1.2.tgz?dl=https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/repeat-string/-/repeat-string-1.6.1.tgz?dl=https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/repeating/-/repeating-2.0.1.tgz?dl=https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
+    },
+    "replace-ext": {
+      "version": "0.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/replace-ext/-/replace-ext-0.0.1.tgz?dl=https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+      "dev": true
+    },
+    "request": {
+      "version": "2.79.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/request/-/request-2.79.0.tgz?dl=https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+      "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.6.0",
+        "aws4": "^1.2.1",
+        "caseless": "~0.11.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.0",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.1.1",
+        "har-validator": "~2.0.6",
+        "hawk": "~3.1.3",
+        "http-signature": "~1.1.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.7",
+        "oauth-sign": "~0.8.1",
+        "qs": "~6.3.0",
+        "stringstream": "~0.0.4",
+        "tough-cookie": "~2.3.0",
+        "tunnel-agent": "~0.4.1",
+        "uuid": "^3.0.0"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.3.2",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/qs/-/qs-6.3.2.tgz?dl=https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.2.1",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/uuid/-/uuid-3.2.1.tgz?dl=https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+          "integrity": "sha1-EsUou51Y0LkmXZovbw/ovhf/HxQ=",
+          "dev": true
+        }
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/require-directory/-/require-directory-2.1.1.tgz?dl=https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/require-main-filename/-/require-main-filename-1.0.1.tgz?dl=https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.1.7",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/resolve/-/resolve-1.1.7.tgz?dl=https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
+    "resolve-dir": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/resolve-dir/-/resolve-dir-0.1.1.tgz?dl=https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+      "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^1.2.2",
+        "global-modules": "^0.2.3"
+      }
+    },
+    "resolve-from": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/resolve-from/-/resolve-from-2.0.0.tgz?dl=https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+      "dev": true
+    },
+    "resolve-pkg": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/resolve-pkg/-/resolve-pkg-0.1.0.tgz?dl=https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-0.1.0.tgz",
+      "integrity": "sha1-AsyZNBDik2livZcWahsHfalyVTE=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^2.0.0"
+      }
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/restore-cursor/-/restore-cursor-1.0.1.tgz?dl=https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
+      }
+    },
+    "rimraf": {
+      "version": "2.2.8",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/rimraf/-/rimraf-2.2.8.tgz?dl=https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+      "dev": true
+    },
+    "run-async": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/run-async/-/run-async-0.1.0.tgz?dl=https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0"
+      }
+    },
+    "rx-lite": {
+      "version": "3.1.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/rx-lite/-/rx-lite-3.1.2.tgz?dl=https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/safe-buffer/-/safe-buffer-5.1.2.tgz?dl=https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+      "dev": true
+    },
+    "safe-json-parse": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/safe-json-parse/-/safe-json-parse-1.0.1.tgz?dl=https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
+      "integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/safer-buffer/-/safer-buffer-2.1.2.tgz?dl=https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+      "dev": true
+    },
+    "sass-graph": {
+      "version": "2.2.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/sass-graph/-/sass-graph-2.2.4.tgz?dl=https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+      "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "lodash": "^4.0.0",
+        "scss-tokenizer": "^0.2.3",
+        "yargs": "^7.0.0"
+      }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/sax/-/sax-1.2.4.tgz?dl=https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
+      "dev": true,
+      "optional": true
+    },
+    "scss-tokenizer": {
+      "version": "0.2.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz?dl=https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+      "dev": true,
+      "requires": {
+        "js-base64": "^2.1.8",
+        "source-map": "^0.4.2"
+      }
+    },
+    "seek-bzip": {
+      "version": "1.0.5",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/seek-bzip/-/seek-bzip-1.0.5.tgz?dl=https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+      "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+      "dev": true,
+      "requires": {
+        "commander": "~2.8.1"
+      }
+    },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/semver/-/semver-5.5.0.tgz?dl=https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs=",
+      "dev": true
+    },
+    "semver-regex": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/semver-regex/-/semver-regex-1.0.0.tgz?dl=https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",
+      "integrity": "sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk=",
+      "dev": true,
+      "optional": true
+    },
+    "semver-truncate": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/semver-truncate/-/semver-truncate-1.1.2.tgz?dl=https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.2.tgz",
+      "integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "semver": "^5.3.0"
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/set-blocking/-/set-blocking-2.0.0.tgz?dl=https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz?dl=https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "dev": true
+    },
+    "shelljs": {
+      "version": "0.3.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/shelljs/-/shelljs-0.3.0.tgz?dl=https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/signal-exit/-/signal-exit-3.0.2.tgz?dl=https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/sntp/-/sntp-1.0.9.tgz?dl=https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.x.x"
+      }
+    },
+    "source-map": {
+      "version": "0.4.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/source-map/-/source-map-0.4.4.tgz?dl=https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "dev": true,
+      "requires": {
+        "amdefine": ">=0.0.4"
+      }
+    },
+    "sparkles": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/sparkles/-/sparkles-1.0.1.tgz?dl=https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+      "integrity": "sha1-AI22XtzmxQ7sDF4ijhlFBh3QQ3w=",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/spdx-correct/-/spdx-correct-3.0.0.tgz?dl=https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha1-BaW01xU6GVvJLDxCW2nzsqlSTII=",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz?dl=https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha1-LHrmEFbHFKW5ubKyr30xHvXHj+k=",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz?dl=https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz?dl=https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha1-enzShHDMbToc/m1miG9rxDDTrIc=",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/sprintf-js/-/sprintf-js-1.0.3.tgz?dl=https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "squeak": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/squeak/-/squeak-1.3.0.tgz?dl=https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz",
+      "integrity": "sha1-MwRQN7ZDiLVnZ0uEMiplIQc5FsM=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "^1.0.0",
+        "console-stream": "^0.1.1",
+        "lpad-align": "^1.0.1"
+      }
+    },
+    "sshpk": {
+      "version": "1.14.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/sshpk/-/sshpk-1.14.1.tgz?dl=https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/assert-plus/-/assert-plus-1.0.0.tgz?dl=https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "stack-trace": {
+      "version": "0.0.9",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/stack-trace/-/stack-trace-0.0.9.tgz?dl=https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+      "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU=",
+      "dev": true
+    },
+    "stat-mode": {
+      "version": "0.2.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/stat-mode/-/stat-mode-0.2.2.tgz?dl=https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
+      "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
+      "dev": true
+    },
+    "stdout-stream": {
+      "version": "1.4.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/stdout-stream/-/stdout-stream-1.4.0.tgz?dl=https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
+      "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "stream-combiner2": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/stream-combiner2/-/stream-combiner2-1.1.1.tgz?dl=https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+      "dev": true,
+      "requires": {
+        "duplexer2": "~0.1.0",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/stream-shift/-/stream-shift-1.0.0.tgz?dl=https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+      "dev": true
+    },
+    "string-template": {
+      "version": "0.2.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string-template/-/string-template-0.2.1.tgz?dl=https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+      "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string-width/-/string-width-1.0.2.tgz?dl=https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string_decoder/-/string_decoder-1.1.1.tgz?dl=https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "stringstream": {
+      "version": "0.0.6",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/stringstream/-/stringstream-0.0.6.tgz?dl=https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha1-eIAiWw1K0Q4wkn0Weh1vL9OzOnI=",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/strip-ansi/-/strip-ansi-3.0.1.tgz?dl=https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/strip-bom/-/strip-bom-2.0.0.tgz?dl=https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
+    },
+    "strip-bom-stream": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz?dl=https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+      "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+      "dev": true,
+      "requires": {
+        "first-chunk-stream": "^1.0.0",
+        "strip-bom": "^2.0.0"
+      }
+    },
+    "strip-dirs": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/strip-dirs/-/strip-dirs-1.1.1.tgz?dl=https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+      "integrity": "sha1-lgu9EoeETzl1pFWKoQOoJV4kVqA=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "is-absolute": "^0.1.5",
+        "is-natural-number": "^2.0.0",
+        "minimist": "^1.1.0",
+        "sum-up": "^1.0.1"
+      }
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/strip-indent/-/strip-indent-1.0.1.tgz?dl=https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/strip-json-comments/-/strip-json-comments-2.0.1.tgz?dl=https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/strip-outer/-/strip-outer-1.0.1.tgz?dl=https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha1-sv0qv2YEudHmATBXGV34Nrip1jE=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
+      }
+    },
+    "sum-up": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/sum-up/-/sum-up-1.0.3.tgz?dl=https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz",
+      "integrity": "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/supports-color/-/supports-color-2.0.0.tgz?dl=https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "susy": {
+      "version": "2.2.14",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/susy/-/susy-2.2.14.tgz?dl=https://registry.npmjs.org/susy/-/susy-2.2.14.tgz",
+      "integrity": "sha1-RVFpD/Bj3SBJGX3YiFuuU0Gpafg=",
+      "dev": true
+    },
+    "svgo": {
+      "version": "0.6.6",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/svgo/-/svgo-0.6.6.tgz?dl=https://registry.npmjs.org/svgo/-/svgo-0.6.6.tgz",
+      "integrity": "sha1-s0CIkDbyD5tEdUMHfQ9Vc+0ETAg=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "coa": "~1.0.1",
+        "colors": "~1.1.2",
+        "csso": "~2.0.0",
+        "js-yaml": "~3.6.0",
+        "mkdirp": "~0.5.1",
+        "sax": "~1.2.1",
+        "whet.extend": "~0.9.9"
+      },
+      "dependencies": {
+        "js-yaml": {
+          "version": "3.6.1",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/js-yaml/-/js-yaml-3.6.1.tgz?dl=https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+          "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^2.6.0"
+          }
+        }
+      }
+    },
+    "tar": {
+      "version": "2.2.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/tar/-/tar-2.2.1.tgz?dl=https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "dev": true,
+      "requires": {
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
+      }
+    },
+    "tar-stream": {
+      "version": "1.6.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/tar-stream/-/tar-stream-1.6.1.tgz?dl=https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
+      "integrity": "sha1-+E7xaWJp1iI8pI9uHu7eP36B85U=",
+      "dev": true,
+      "requires": {
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.1.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "tempfile": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/tempfile/-/tempfile-1.1.1.tgz?dl=https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
+      "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "^1.0.0",
+        "uuid": "^2.0.1"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/through/-/through-2.3.8.tgz?dl=https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "through2": {
+      "version": "0.6.5",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/through2/-/through2-0.6.5.tgz?dl=https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+      "dev": true,
+      "requires": {
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/isarray/-/isarray-0.0.1.tgz?dl=https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/readable-stream/-/readable-stream-1.0.34.tgz?dl=https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/string_decoder/-/string_decoder-0.10.31.tgz?dl=https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "through2-filter": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/through2-filter/-/through2-filter-2.0.0.tgz?dl=https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+      "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+      "dev": true,
+      "requires": {
+        "through2": "~2.0.0",
+        "xtend": "~4.0.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.3",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/through2/-/through2-2.0.3.tgz?dl=https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
+          }
+        }
+      }
+    },
+    "time-stamp": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/time-stamp/-/time-stamp-1.1.0.tgz?dl=https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+      "dev": true
+    },
+    "timed-out": {
+      "version": "3.1.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/timed-out/-/timed-out-3.1.3.tgz?dl=https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
+      "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
+      "dev": true
+    },
+    "tiny-lr": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/tiny-lr/-/tiny-lr-1.1.1.tgz?dl=https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
+      "integrity": "sha1-n6VHQS8jj+2waO4pWvi2gsmLKqs=",
+      "dev": true,
+      "requires": {
+        "body": "^5.1.0",
+        "debug": "^3.1.0",
+        "faye-websocket": "~0.10.0",
+        "livereload-js": "^2.3.0",
+        "object-assign": "^4.1.0",
+        "qs": "^6.4.0"
+      }
+    },
+    "to-absolute-glob": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz?dl=https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+      "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1"
+      }
+    },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/to-buffer/-/to-buffer-1.1.1.tgz?dl=https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha1-STvUj2LXxD/N7TE6A9ytsuEhOoA=",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/tough-cookie/-/tough-cookie-2.3.4.tgz?dl=https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
+      "dev": true,
+      "requires": {
+        "punycode": "^1.4.1"
+      }
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/trim-newlines/-/trim-newlines-1.0.0.tgz?dl=https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
+    "trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/trim-repeated/-/trim-repeated-1.0.0.tgz?dl=https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
+      }
+    },
+    "true-case-path": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/true-case-path/-/true-case-path-1.0.2.tgz?dl=https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
+      "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
+      "dev": true,
+      "requires": {
+        "glob": "^6.0.4"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/glob/-/glob-6.0.4.tgz?dl=https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/tunnel-agent/-/tunnel-agent-0.4.3.tgz?dl=https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+      "dev": true
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/tweetnacl/-/tweetnacl-0.14.5.tgz?dl=https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "optional": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/typedarray/-/typedarray-0.0.6.tgz?dl=https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "underscore.string": {
+      "version": "3.2.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/underscore.string/-/underscore.string-3.2.3.tgz?dl=https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz",
+      "integrity": "sha1-gGmSYzZl1eX8tNsfs6hi62jp5to=",
+      "dev": true
+    },
+    "unique-stream": {
+      "version": "2.2.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/unique-stream/-/unique-stream-2.2.1.tgz?dl=https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+      "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+      "dev": true,
+      "requires": {
+        "json-stable-stringify": "^1.0.0",
+        "through2-filter": "^2.0.0"
+      }
+    },
+    "unzip-response": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/unzip-response/-/unzip-response-1.0.2.tgz?dl=https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
+      "dev": true
+    },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/url-parse-lax/-/url-parse-lax-1.0.0.tgz?dl=https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "^1.0.1"
+      }
+    },
+    "url-regex": {
+      "version": "3.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/url-regex/-/url-regex-3.2.0.tgz?dl=https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz",
+      "integrity": "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "ip-regex": "^1.0.1"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/util-deprecate/-/util-deprecate-1.0.2.tgz?dl=https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "2.0.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/uuid/-/uuid-2.0.3.tgz?dl=https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+      "dev": true
+    },
+    "vali-date": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/vali-date/-/vali-date-1.0.0.tgz?dl=https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+      "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz?dl=https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha1-gWQ7y+8b3+zUYjeT3EZIlIupgzg=",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/verror/-/verror-1.10.0.tgz?dl=https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/assert-plus/-/assert-plus-1.0.0.tgz?dl=https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "vinyl": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/vinyl/-/vinyl-1.2.0.tgz?dl=https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+      "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.0",
+        "clone-stats": "^0.0.1",
+        "replace-ext": "0.0.1"
+      }
+    },
+    "vinyl-assign": {
+      "version": "1.2.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/vinyl-assign/-/vinyl-assign-1.2.1.tgz?dl=https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz",
+      "integrity": "sha1-TRmIkbVRWRHXcajNnFSApGoHSkU=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.0.1",
+        "readable-stream": "^2.0.0"
+      }
+    },
+    "vinyl-fs": {
+      "version": "2.4.4",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/vinyl-fs/-/vinyl-fs-2.4.4.tgz?dl=https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+      "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+      "dev": true,
+      "requires": {
+        "duplexify": "^3.2.0",
+        "glob-stream": "^5.3.2",
+        "graceful-fs": "^4.0.0",
+        "gulp-sourcemaps": "1.6.0",
+        "is-valid-glob": "^0.3.0",
+        "lazystream": "^1.0.0",
+        "lodash.isequal": "^4.0.0",
+        "merge-stream": "^1.0.0",
+        "mkdirp": "^0.5.0",
+        "object-assign": "^4.0.0",
+        "readable-stream": "^2.0.4",
+        "strip-bom": "^2.0.0",
+        "strip-bom-stream": "^1.0.0",
+        "through2": "^2.0.0",
+        "through2-filter": "^2.0.0",
+        "vali-date": "^1.0.0",
+        "vinyl": "^1.0.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.3",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/through2/-/through2-2.0.3.tgz?dl=https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
+          }
+        }
+      }
+    },
+    "ware": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ware/-/ware-1.3.0.tgz?dl=https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
+      "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
+      "dev": true,
+      "requires": {
+        "wrap-fn": "^0.1.0"
+      }
+    },
+    "websocket-driver": {
+      "version": "0.7.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/websocket-driver/-/websocket-driver-0.7.0.tgz?dl=https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+      "dev": true,
+      "requires": {
+        "http-parser-js": ">=0.4.0",
+        "websocket-extensions": ">=0.1.1"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.3",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/websocket-extensions/-/websocket-extensions-0.1.3.tgz?dl=https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "integrity": "sha1-XS/yKXcAPsaHpLhwc9+7rBRszyk=",
+      "dev": true
+    },
+    "whet.extend": {
+      "version": "0.9.9",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/whet.extend/-/whet.extend-0.9.9.tgz?dl=https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+      "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
+      "dev": true,
+      "optional": true
+    },
+    "which": {
+      "version": "1.2.14",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/which/-/which-1.2.14.tgz?dl=https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/which-module/-/which-module-1.0.0.tgz?dl=https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/wide-align/-/wide-align-1.1.2.tgz?dl=https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2"
+      }
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/wrap-ansi/-/wrap-ansi-2.1.0.tgz?dl=https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      }
+    },
+    "wrap-fn": {
+      "version": "0.1.5",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/wrap-fn/-/wrap-fn-0.1.5.tgz?dl=https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
+      "integrity": "sha1-8htuQQFv9KfjFyDbxjoJAWvfmEU=",
+      "dev": true,
+      "requires": {
+        "co": "3.1.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/wrappy/-/wrappy-1.0.2.tgz?dl=https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/xtend/-/xtend-4.0.1.tgz?dl=https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/y18n/-/y18n-3.2.1.tgz?dl=https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/yallist/-/yallist-2.1.2.tgz?dl=https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "7.1.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/yargs/-/yargs-7.1.0.tgz?dl=https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+      "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^3.0.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^1.4.0",
+        "read-pkg-up": "^1.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^1.0.2",
+        "which-module": "^1.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^5.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/camelcase/-/camelcase-3.0.0.tgz?dl=https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "5.0.0",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/yargs-parser/-/yargs-parser-5.0.0.tgz?dl=https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+      "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^3.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/camelcase/-/camelcase-3.0.0.tgz?dl=https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        }
+      }
+    },
+    "yauzl": {
+      "version": "2.9.1",
+      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/yauzl/-/yauzl-2.9.1.tgz?dl=https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
+      "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.0.1"
+      }
+    }
+  }
+}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -843,7 +843,7 @@ body.no-max-width .main-navigation {
       color: #ffffff; }
     .navigation.pagination .nav-links {
       float: left; }
-      .navigation.pagination .nav-links .page-numbers:not(.prev):not(.next) {
+      .navigation.pagination .nav-links .page-numbers {
         display: none; } }
 
 .site-main .comment-navigation, .site-main
@@ -1842,7 +1842,8 @@ body.no-max-width .footer-widget-area {
 
 .site-info-wrapper {
   padding: 1.5em 0;
-  background-color: #ffffff; }
+  background-color: #ffffff;
+  text-align: none; }
   .site-info-wrapper .site-info {
     max-width: 1100px;
     margin-right: auto;
@@ -1851,6 +1852,11 @@ body.no-max-width .footer-widget-area {
       content: " ";
       display: block;
       clear: both; }
+  .site-info-wrapper .privacy-policy-link {
+    display: inline-block;
+    font-size: 75%;
+    line-height: 1.2;
+    margin: 0 1.38889%; }
   .site-info-wrapper .site-info-text {
     width: 97.22222%;
     float: right;
@@ -1866,12 +1872,18 @@ body.no-max-width .footer-widget-area {
     margin-right: 1.38889%;
     margin-left: 1.38889%; }
   @media only screen and (max-width: 40.063em) {
-    .site-info-wrapper .social-menu {
-      width: 97.22222%;
-      float: right;
-      margin-right: 1.38889%;
-      margin-left: 1.38889%;
-      text-align: center; } }
+    .site-info-wrapper {
+      text-align: center; }
+      .site-info-wrapper .social-menu {
+        width: 97.22222%;
+        float: right;
+        margin-right: 1.38889%;
+        margin-left: 1.38889%;
+        text-align: center; }
+        .site-info-wrapper .social-menu + .privacy-policy-link {
+          padding-top: 3em; }
+      .site-info-wrapper .privacy-policy-link {
+        text-align: center; } }
 
 body.no-max-width .site-info-wrapper .site-info {
   max-width: none; }
@@ -2225,6 +2237,20 @@ body.no-max-width .site-info-wrapper .site-info {
   .comments-area input:not(.submit),
   .comments-area textarea {
     width: 100%; }
+  .comments-area .comment-form-cookies-consent {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: flex;
+    line-height: 16px; }
+    .comments-area .comment-form-cookies-consent #wp-comment-cookies-consent {
+      display: inline;
+      width: auto;
+      margin: 0 0 0 10px; }
+      @media only screen and (max-width: 40.063em) {
+        .comments-area .comment-form-cookies-consent #wp-comment-cookies-consent {
+          margin-top: 2px; } }
 
 .comment-list {
   padding: 0;

--- a/style.css
+++ b/style.css
@@ -843,7 +843,7 @@ body.no-max-width .main-navigation {
       color: #ffffff; }
     .navigation.pagination .nav-links {
       float: right; }
-      .navigation.pagination .nav-links .page-numbers:not(.prev):not(.next) {
+      .navigation.pagination .nav-links .page-numbers {
         display: none; } }
 
 .site-main .comment-navigation, .site-main
@@ -1842,7 +1842,8 @@ body.no-max-width .footer-widget-area {
 
 .site-info-wrapper {
   padding: 1.5em 0;
-  background-color: #ffffff; }
+  background-color: #ffffff;
+  text-align: none; }
   .site-info-wrapper .site-info {
     max-width: 1100px;
     margin-left: auto;
@@ -1851,6 +1852,11 @@ body.no-max-width .footer-widget-area {
       content: " ";
       display: block;
       clear: both; }
+  .site-info-wrapper .privacy-policy-link {
+    display: inline-block;
+    font-size: 75%;
+    line-height: 1.2;
+    margin: 0 1.38889%; }
   .site-info-wrapper .site-info-text {
     width: 97.22222%;
     float: left;
@@ -1866,12 +1872,18 @@ body.no-max-width .footer-widget-area {
     margin-left: 1.38889%;
     margin-right: 1.38889%; }
   @media only screen and (max-width: 40.063em) {
-    .site-info-wrapper .social-menu {
-      width: 97.22222%;
-      float: left;
-      margin-left: 1.38889%;
-      margin-right: 1.38889%;
-      text-align: center; } }
+    .site-info-wrapper {
+      text-align: center; }
+      .site-info-wrapper .social-menu {
+        width: 97.22222%;
+        float: left;
+        margin-left: 1.38889%;
+        margin-right: 1.38889%;
+        text-align: center; }
+        .site-info-wrapper .social-menu + .privacy-policy-link {
+          padding-top: 3em; }
+      .site-info-wrapper .privacy-policy-link {
+        text-align: center; } }
 
 body.no-max-width .site-info-wrapper .site-info {
   max-width: none; }
@@ -2225,6 +2237,20 @@ body.no-max-width .site-info-wrapper .site-info {
   .comments-area input:not(.submit),
   .comments-area textarea {
     width: 100%; }
+  .comments-area .comment-form-cookies-consent {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: flex;
+    line-height: 16px; }
+    .comments-area .comment-form-cookies-consent #wp-comment-cookies-consent {
+      display: inline;
+      width: auto;
+      margin: 0 10px 0 0; }
+      @media only screen and (max-width: 40.063em) {
+        .comments-area .comment-form-cookies-consent #wp-comment-cookies-consent {
+          margin-top: 2px; } }
 
 .comment-list {
   padding: 0;


### PR DESCRIPTION
Resolves #22 

Introduce WordPress 4.9.6 support
- Update privacy link and comment cookie styles for WordPress 4.9.6 support

Related Primer PR:
godaddy/wp-primer-theme#254